### PR TITLE
display_timings: fix VS_END typo (HS_STA -> VS_STA)

### DIFF
--- a/fpga-ad-astra/display_timings.sv
+++ b/fpga-ad-astra/display_timings.sv
@@ -24,7 +24,7 @@ module display_timings (
     // vertical timings
     parameter VA_END = 479;             // end of active pixels
     parameter VS_STA = VA_END + 10;     // sync starts after front porch
-    parameter VS_END = HS_STA + 2;      // sync ends
+    parameter VS_END = VS_STA + 2;      // sync ends
     parameter SCREEN = 524;             // last line on screen (after back porch)
 
     always_comb begin

--- a/fpga-graphics/display_timings.sv
+++ b/fpga-graphics/display_timings.sv
@@ -24,7 +24,7 @@ module display_timings (
     // vertical timings
     parameter VA_END = 479;             // end of active pixels
     parameter VS_STA = VA_END + 10;     // sync starts after front porch
-    parameter VS_END = HS_STA + 2;      // sync ends
+    parameter VS_END = VS_STA + 2;      // sync ends
     parameter SCREEN = 524;             // last line on screen (after back porch)
 
     always_comb begin

--- a/fpga-pong/display_timings.sv
+++ b/fpga-pong/display_timings.sv
@@ -24,7 +24,7 @@ module display_timings (
     // vertical timings
     parameter VA_END = 479;             // end of active pixels
     parameter VS_STA = VA_END + 10;     // sync starts after front porch
-    parameter VS_END = HS_STA + 2;      // sync ends
+    parameter VS_END = VS_STA + 2;      // sync ends
     parameter SCREEN = 524;             // last line on screen (after back porch)
 
     always_comb begin


### PR DESCRIPTION
line
```
parameter VS_END = HS_STA + 2;
```
must be 
```
parameter VS_END = VS_STA + 2;
```