### PR TITLE
Framebuffer Double Buffering Bug Fixes

### DIFF
--- a/graphics/animated-shapes/xc7/top_cube_pieces.sv
+++ b/graphics/animated-shapes/xc7/top_cube_pieces.sv
@@ -56,6 +56,7 @@ module top_cube_pieces (
     localparam FB_SCALE   = 2;
     localparam FB_IMAGE   = "";
     localparam FB_PALETTE = "16_colr_4bit_palette.mem";
+    localparam BG_IDX     = 4'h5;  // background colour
 
     logic fb_we, fb_busy, fb_wready;
     logic signed [CORDW-1:0] fbx, fby;  // framebuffer coordinates
@@ -82,7 +83,7 @@ module top_cube_pieces (
         .x(fbx),
         .y(fby),
         .cidx(fb_cidx),
-        .bgidx(4'h0),
+        .bgidx(BG_IDX),
         .clear(1'b1),  // enable clearing of buffer before drawing
         .busy(fb_busy),
         .wready(fb_wready),
@@ -95,10 +96,10 @@ module top_cube_pieces (
     );
 
     // animate triangle coordinates
-    localparam MAX_OFFS   = 32;  // maximum pixels to move
-    localparam ANIM_SPEED =  1;  // pixel to move per frame
-    localparam FRAME_WAIT = 60;  // frames to pause between change of direction
-    logic [CORDW-1:0] offs;      // animation offset
+    localparam MAX_OFFS   = 200;  // maximum pixels to move
+    localparam ANIM_SPEED =   2;  // pixel to move per frame
+    localparam FRAME_WAIT =  60;  // frames to pause between change of direction
+    logic [CORDW-1:0] offs;       // animation offset
     logic [$clog2(FRAME_WAIT)-1:0] cnt_frame_wait;
     logic dir;  // direction: 1 is increasing offset
     enum {START, MOVE, WAIT} anim_state;

--- a/lib/display/framebuffer_bram_db.sv
+++ b/lib/display/framebuffer_bram_db.sv
@@ -1,5 +1,5 @@
 // Project F Library - Double-Buffered Framebuffer in BRAM (Indexed Colour)
-// (C)2021 Will Green, Open Source Hardware released under the MIT License
+// (C)2022 Will Green, Open Source Hardware released under the MIT License
 // Learn more at https://projectf.io
 
 `default_nettype none

--- a/lib/display/xc7/framebuffer_bram_db_tb.sv
+++ b/lib/display/xc7/framebuffer_bram_db_tb.sv
@@ -51,7 +51,7 @@ module framebuffer_bram_db_tb();
     localparam FB_HEIGHT  = 9;
     localparam FB_CIDXW   = 4;
     localparam FB_CHANW   = 4;
-    localparam FB_IMAGE   = "test_box_db_12x9.mem";
+    localparam FB_IMAGE   = "";
     localparam FB_PALETTE = "test_palette.mem";
     localparam FB_SCALE   = 2;  // use =1 with fb active = (sy >=0 ....
 
@@ -115,10 +115,11 @@ module framebuffer_bram_db_tb();
                 end
             DRAW: 
                 if (!fb_busy) begin
-                    if (fbx < FB_WIDTH-1) begin
+                    if (fbx < FB_WIDTH+4) begin
                         fbx <= fbx + 1;
                     end else begin
                         fb_we <= 0;
+                        fb_cidx <= 4'hF;
                         state <= DONE;
                     end
                 end
@@ -169,6 +170,6 @@ module framebuffer_bram_db_tb();
         #28140
         fb_clear = 1;
 
-        #120000 $finish;
+        #200000 $finish;
     end
 endmodule

--- a/lib/display/xc7/vivado/framebuffer_bram_db_tb_behav.wcfg
+++ b/lib/display/xc7/vivado/framebuffer_bram_db_tb_behav.wcfg
@@ -11,15 +11,15 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="31308288fs"></ZoomStartTime>
-      <ZoomEndTime time="42798289fs"></ZoomEndTime>
-      <Cursor1Time time="148240000fs"></Cursor1Time>
+      <ZoomStartTime time="0.000000 us"></ZoomStartTime>
+      <ZoomEndTime time="228.240001 us"></ZoomEndTime>
+      <Cursor1Time time="85.530000 us"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
       <NameColumnWidth column_width="197"></NameColumnWidth>
-      <ValueColumnWidth column_width="71"></ValueColumnWidth>
+      <ValueColumnWidth column_width="63"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="84" />
+   <WVObjectSize size="89" />
    <wvobject fp_name="/framebuffer_bram_db_tb/clk_25m" type="logic">
       <obj_property name="ElementShortName">clk_25m</obj_property>
       <obj_property name="ObjectShortName">clk_25m</obj_property>
@@ -255,12 +255,12 @@
       <obj_property name="ObjectShortName">front_buf</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_read" type="array">
-      <obj_property name="ElementShortName">fb_addr_read[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_read[7:0]</obj_property>
+      <obj_property name="ElementShortName">fb_addr_read[6:0]</obj_property>
+      <obj_property name="ObjectShortName">fb_addr_read[6:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_write" type="array">
-      <obj_property name="ElementShortName">fb_addr_write[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_write[7:0]</obj_property>
+      <obj_property name="ElementShortName">fb_addr_write[6:0]</obj_property>
+      <obj_property name="ObjectShortName">fb_addr_write[6:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_cidx_read" type="array">
       <obj_property name="ElementShortName">fb_cidx_read[3:0]</obj_property>
@@ -275,12 +275,12 @@
       <obj_property name="ObjectShortName">x_add[15:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_line" type="array">
-      <obj_property name="ElementShortName">fb_addr_line[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_line[7:0]</obj_property>
+      <obj_property name="ElementShortName">fb_addr_line[6:0]</obj_property>
+      <obj_property name="ObjectShortName">fb_addr_line[6:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_clr" type="array">
-      <obj_property name="ElementShortName">fb_addr_clr[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_clr[7:0]</obj_property>
+      <obj_property name="ElementShortName">fb_addr_clr[6:0]</obj_property>
+      <obj_property name="ObjectShortName">fb_addr_clr[6:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/wstate" type="array">
       <obj_property name="ElementShortName">wstate[31:0]</obj_property>
@@ -290,25 +290,9 @@
       <obj_property name="ElementShortName">fb_we</obj_property>
       <obj_property name="ObjectShortName">fb_we</obj_property>
    </wvobject>
-   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/we_in_p1" type="logic">
-      <obj_property name="ElementShortName">we_in_p1</obj_property>
-      <obj_property name="ObjectShortName">we_in_p1</obj_property>
-   </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_cidx_write" type="array">
       <obj_property name="ElementShortName">fb_cidx_write[3:0]</obj_property>
       <obj_property name="ObjectShortName">fb_cidx_write[3:0]</obj_property>
-   </wvobject>
-   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/cidx_in_p1" type="array">
-      <obj_property name="ElementShortName">cidx_in_p1[3:0]</obj_property>
-      <obj_property name="ObjectShortName">cidx_in_p1[3:0]</obj_property>
-   </wvobject>
-   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_read_offs" type="array">
-      <obj_property name="ElementShortName">fb_addr_read_offs[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_read_offs[7:0]</obj_property>
-   </wvobject>
-   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/fb_addr_write_offs" type="array">
-      <obj_property name="ElementShortName">fb_addr_write_offs[7:0]</obj_property>
-      <obj_property name="ObjectShortName">fb_addr_write_offs[7:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/lb_data_req" type="logic">
       <obj_property name="ElementShortName">lb_data_req</obj_property>
@@ -361,5 +345,42 @@
    <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/lb_en_out_p1" type="logic">
       <obj_property name="ElementShortName">lb_en_out_p1</obj_property>
       <obj_property name="ObjectShortName">lb_en_out_p1</obj_property>
+   </wvobject>
+   <wvobject type="divider" fp_name="divider340">
+      <obj_property name="label">BRAM</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/clk_write" type="logic">
+      <obj_property name="ElementShortName">clk_write</obj_property>
+      <obj_property name="ObjectShortName">clk_write</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/clk_read" type="logic">
+      <obj_property name="ElementShortName">clk_read</obj_property>
+      <obj_property name="ObjectShortName">clk_read</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/we" type="logic">
+      <obj_property name="ElementShortName">we</obj_property>
+      <obj_property name="ObjectShortName">we</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/addr_write" type="array">
+      <obj_property name="ElementShortName">addr_write[7:0]</obj_property>
+      <obj_property name="ObjectShortName">addr_write[7:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/addr_read" type="array">
+      <obj_property name="ElementShortName">addr_read[7:0]</obj_property>
+      <obj_property name="ObjectShortName">addr_read[7:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/data_in" type="array">
+      <obj_property name="ElementShortName">data_in[3:0]</obj_property>
+      <obj_property name="ObjectShortName">data_in[3:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/data_out" type="array">
+      <obj_property name="ElementShortName">data_out[3:0]</obj_property>
+      <obj_property name="ObjectShortName">data_out[3:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/framebuffer_bram_db_tb/fb_inst/bram_inst/memory" type="array">
+      <obj_property name="ElementShortName">memory[0:255][3:0]</obj_property>
+      <obj_property name="ObjectShortName">memory[0:255][3:0]</obj_property>
+      <obj_property name="isExpanded"></obj_property>
    </wvobject>
 </wave_config>


### PR DESCRIPTION
Fixes a couple of bugs with the original Project F double-buffered framebuffer.

* Correctly clears first pixel in buffer
* Clipping doesn't prevent screen clearing
* Updates shattered cube demo