### PR TITLE
Add 2022 clock designs to library.

### DIFF
--- a/lib/clock/ice40/clock_480p.sv
+++ b/lib/clock/ice40/clock_480p.sv
@@ -1,0 +1,45 @@
+// Project F Library - 640x480p60 Clock Generation (iCE40)
+// (C)2022 Will Green, open source hardware released under the MIT License
+// Learn more at https://projectf.io
+
+`default_nettype none
+`timescale 1ns / 1ps
+
+// Generates 25.125 MHz (640x480 59.8 Hz) with 12 MHz input clock
+// iCE40 PLLs are documented in Lattice TN1251 and ICE Technology Library
+
+module clock_480p (
+    input  wire logic clk_12m,        // input clock (12 MHz)
+    input  wire logic rst,            // reset
+    output      logic clk_pix,        // pixel clock
+    output      logic clk_pix_locked  // pixel clock locked?
+    );
+
+    localparam FEEDBACK_PATH="SIMPLE";
+    localparam DIVR=4'b0000;
+    localparam DIVF=7'b1000010;
+    localparam DIVQ=3'b101;
+    localparam FILTER_RANGE=3'b001;
+
+    logic locked;
+    SB_PLL40_PAD #(
+        .FEEDBACK_PATH(FEEDBACK_PATH),
+        .DIVR(DIVR),
+        .DIVF(DIVF),
+        .DIVQ(DIVQ),
+        .FILTER_RANGE(FILTER_RANGE)
+    ) SB_PLL40_PAD_inst (
+        .PACKAGEPIN(clk_12m),
+        .PLLOUTGLOBAL(clk_pix),  // use global clock network
+        .RESETB(rst),
+        .BYPASS(1'b0),
+        .LOCK(locked)
+    );
+
+    // ensure clock lock is synced with pixel clock
+    logic locked_sync_0;
+    always_ff @(posedge clk_pix) begin
+        locked_sync_0 <= locked;
+        clk_pix_locked <= locked_sync_0;
+    end
+endmodule

--- a/lib/clock/xc7/clock_480p.sv
+++ b/lib/clock/xc7/clock_480p.sv
@@ -1,0 +1,69 @@
+// Project F Library - 640x480p60 Clock Generation (XC7)
+// (C)2022 Will Green, open source hardware released under the MIT License
+// Learn more at https://projectf.io
+
+`default_nettype none
+`timescale 1ns / 1ps
+
+// Generates 25.2 MHz (640x480 60 Hz) with 100 MHz input clock
+// MMCME2_BASE and BUFG are documented in Xilinx UG472
+
+module clock_480p (
+    input  wire logic clk_100m,       // input clock (100 MHz)
+    input  wire logic rst,            // reset
+    output      logic clk_pix,        // pixel clock
+    output      logic clk_pix_5x,     // 5x clock for 10:1 DDR SerDes
+    output      logic clk_pix_locked  // pixel clock locked?
+    );
+
+    localparam MULT_MASTER=31.5;  // master clock multiplier (2.000-64.000)
+    localparam DIV_MASTER=5;      // master clock divider (1-106)
+    localparam DIV_5X=5.0;        // 5x pixel clock divider
+    localparam DIV_1X=25;         // pixel clock divider
+    localparam IN_PERIOD=10.0;    // period of master clock in ns (10 ns == 100 MHz)
+
+    logic feedback;          // internal clock feedback
+    logic clk_pix_unbuf;     // unbuffered pixel clock
+    logic clk_pix_5x_unbuf;  // unbuffered 5x pixel clock
+    logic locked;            // unsynced lock signal
+
+    MMCME2_BASE #(
+        .CLKFBOUT_MULT_F(MULT_MASTER),
+        .CLKIN1_PERIOD(IN_PERIOD),
+        .CLKOUT0_DIVIDE_F(DIV_5X),
+        .CLKOUT1_DIVIDE(DIV_1X),
+        .DIVCLK_DIVIDE(DIV_MASTER)
+    ) MMCME2_BASE_inst (
+        .CLKIN1(clk_100m),
+        .RST(rst),
+        .CLKOUT0(clk_pix_5x_unbuf),
+        .CLKOUT1(clk_pix_unbuf),
+        .LOCKED(locked),
+        .CLKFBOUT(feedback),
+        .CLKFBIN(feedback),
+        /* verilator lint_off PINCONNECTEMPTY */
+        .CLKOUT0B(),
+        .CLKOUT1B(),
+        .CLKOUT2(),
+        .CLKOUT2B(),
+        .CLKOUT3(),
+        .CLKOUT3B(),
+        .CLKOUT4(),
+        .CLKOUT5(),
+        .CLKOUT6(),
+        .CLKFBOUTB(),
+        .PWRDWN()
+        /* verilator lint_on PINCONNECTEMPTY */
+    );
+
+    // explicitly buffer output clocks
+    BUFG bufg_clk(.I(clk_pix_unbuf), .O(clk_pix));
+    BUFG bufg_clk_5x(.I(clk_pix_5x_unbuf), .O(clk_pix_5x));
+
+    // ensure clock lock is synced with pixel clock
+    logic locked_sync_0;
+    always_ff @(posedge clk_pix) begin
+        locked_sync_0 <= locked;
+        clk_pix_locked <= locked_sync_0;
+    end
+endmodule

--- a/lib/clock/xc7/clock_720p.sv
+++ b/lib/clock/xc7/clock_720p.sv
@@ -1,0 +1,69 @@
+// Project F Library - 1280x720p60 Clock Generation (XC7)
+// (C)2022 Will Green, Open source hardware released under the MIT License
+// Learn more at https://projectf.io
+
+`default_nettype none
+`timescale 1ns / 1ps
+
+// Generates 74.25 MHz (1280x720 60 Hz) with 100 MHz input clock
+// MMCME2_BASE and BUFG are documented in Xilinx UG472
+
+module clock_720p (
+    input  wire logic clk_100m,       // input clock (100 MHz)
+    input  wire logic rst,            // reset
+    output      logic clk_pix,        // pixel clock
+    output      logic clk_pix_5x,     // 5x clock for 10:1 DDR SerDes
+    output      logic clk_pix_locked  // pixel clock locked?
+    );
+
+    localparam MULT_MASTER=37.125;  // master clock multiplier
+    localparam DIV_MASTER=5;        // master clock divider
+    localparam DIV_5X=2.0;          // 5x pixel clock divider
+    localparam DIV_1X=10;           // pixel clock divider
+    localparam IN_PERIOD=10.0;      // period of master clock in ns (10 ns == 100 MHz)
+
+    logic feedback;          // internal clock feedback
+    logic clk_pix_unbuf;     // unbuffered pixel clock
+    logic clk_pix_5x_unbuf;  // unbuffered 5x pixel clock
+    logic locked;            // unsynced lock signal
+
+    MMCME2_BASE #(
+        .CLKFBOUT_MULT_F(MULT_MASTER),
+        .CLKIN1_PERIOD(IN_PERIOD),
+        .CLKOUT0_DIVIDE_F(DIV_5X),
+        .CLKOUT1_DIVIDE(DIV_1X),
+        .DIVCLK_DIVIDE(DIV_MASTER)
+    ) MMCME2_BASE_inst (
+        .CLKIN1(clk_100m),
+        .RST(rst),
+        .CLKOUT0(clk_pix_5x_unbuf),
+        .CLKOUT1(clk_pix_unbuf),
+        .LOCKED(locked),
+        .CLKFBOUT(feedback),
+        .CLKFBIN(feedback),
+        /* verilator lint_off PINCONNECTEMPTY */
+        .CLKOUT0B(),
+        .CLKOUT1B(),
+        .CLKOUT2(),
+        .CLKOUT2B(),
+        .CLKOUT3(),
+        .CLKOUT3B(),
+        .CLKOUT4(),
+        .CLKOUT5(),
+        .CLKOUT6(),
+        .CLKFBOUTB(),
+        .PWRDWN()
+        /* verilator lint_on PINCONNECTEMPTY */
+    );
+
+    // explicitly buffer output clocks
+    BUFG bufg_clk(.I(clk_pix_unbuf), .O(clk_pix));
+    BUFG bufg_clk_5x(.I(clk_pix_5x_unbuf), .O(clk_pix_5x));
+
+    // ensure clock lock is synced with pixel clock
+    logic locked_sync_0;
+    always_ff @(posedge clk_pix) begin
+        locked_sync_0 <= locked;
+        clk_pix_locked <= locked_sync_0;
+    end
+endmodule

--- a/lib/clock/xc7/clock_tb.sv
+++ b/lib/clock/xc7/clock_tb.sv
@@ -1,0 +1,50 @@
+// Project F Library - Clock Generation Test Bench (XC7)
+// (C)2022 Will Green, open source hardware released under the MIT License
+// Learn more at https://projectf.io
+
+`default_nettype none
+`timescale 1ns / 1ps
+
+module clock_tb ();
+
+    parameter CLK_PERIOD = 10;
+
+    logic rst, clk_100m;
+
+    // 640x480p60 clocks
+    logic clk_480p, clk_480p_5x;
+    logic clk_locked_480p;
+
+    clock_480p clock_480p_inst (
+       .clk_100m,
+       .rst,
+       .clk_pix(clk_480p),
+       .clk_pix_5x(clk_480p_5x),
+       .clk_locked(clk_locked_480p)
+    );
+
+    // 1280x720p60 clocks
+    logic clk_720p, clk_720p_5x;
+    logic clk_locked_720p;
+
+    clock_720p clock_720p_inst (
+       .clk_100m,
+       .rst,
+       .clk_pix(clk_720p),
+       .clk_pix_5x(clk_720p_5x),
+       .clk_locked(clk_locked_720p)
+    );
+
+    always #(CLK_PERIOD / 2) clk_100m = ~clk_100m;
+
+    initial begin
+        clk_100m = 1;
+        rst = 1;
+        #100
+        rst = 0;
+
+        #12000
+        $finish;
+    end
+
+endmodule


### PR DESCRIPTION
No projf-explore designs use these clocks (yet).