### PR TITLE
Makefile Continuation Fix

### DIFF
--- a/graphics/fpga-graphics/ice40/Makefile
+++ b/graphics/fpga-graphics/ice40/Makefile
@@ -19,8 +19,7 @@ flag_sweden: flag_sweden.rpt flag_sweden.bin
 colour: colour.rpt colour.bin
 
 %.json: top_%.sv $(ADD_SRC)
-	yosys -ql $(basename $@)-yosys.log -p 'synth_ice40 -abc9 -device u \
-		-top top_$(basename $@) -json $@' $< $(ADD_SRC)
+	yosys -ql $(basename $@)-yosys.log -p 'synth_ice40 -abc9 -device u -top top_$(basename $@) -json $@' $< $(ADD_SRC)
 
 %.asc: %.json
 	nextpnr-ice40 --${FPGA_TYPE} --package ${FPGA_PKG} --json $< --pcf ${PCF} --asc $@

--- a/graphics/racing-the-beam/ice40/Makefile
+++ b/graphics/racing-the-beam/ice40/Makefile
@@ -20,8 +20,7 @@ colour_cycle: colour_cycle.rpt colour_cycle.bin
 bounce: bounce.rpt bounce.bin
 
 %.json: top_%.sv $(ADD_SRC)
-	yosys -ql $(basename $@)-yosys.log -p 'synth_ice40 -abc9 -device u \
-		-top top_$(basename $@) -json $@' $< $(ADD_SRC)
+	yosys -ql $(basename $@)-yosys.log -p 'synth_ice40 -abc9 -device u -top top_$(basename $@) -json $@' $< $(ADD_SRC)
 
 %.asc: %.json
 	nextpnr-ice40 --${FPGA_TYPE} --package ${FPGA_PKG} --json $< --pcf ${PCF} --asc $@


### PR DESCRIPTION
Some versions of make(1) don't like continuation within string:
`Warning: Selection "\" did not match any module.`
GNU Make 4.2.1 as included in Ubuntu 20.04 has this issue.

Thanks to Xark (https://github.com/XarkLabs) for reporting this.