### PR TITLE
Line signal applies to all lines (not just active ones).

### DIFF
--- a/lib/display/display_1080p.sv
+++ b/lib/display/display_1080p.sv
@@ -24,7 +24,7 @@ module display_1080p #(
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
     output      logic frame,    // high at start of frame
-    output      logic line,     // high at start of active line
+    output      logic line,     // high at start of line
     output      logic signed [CORDW-1:0] sx,  // horizontal screen position
     output      logic signed [CORDW-1:0] sy   // vertical screen position
     );
@@ -57,7 +57,7 @@ module display_1080p #(
     always_ff @(posedge clk_pix) begin
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
-        line  <= (y >= VA_STA && x == H_STA);
+        line  <= (x == H_STA);
         if (rst) begin
             de <= 0;
             frame <= 0;

--- a/lib/display/display_24x18.sv
+++ b/lib/display/display_24x18.sv
@@ -24,7 +24,7 @@ module display_24x18 #(
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
     output      logic frame,    // high at start of frame
-    output      logic line,     // high at start of active line
+    output      logic line,     // high at start of line
     output      logic signed [CORDW-1:0] sx,  // horizontal screen position
     output      logic signed [CORDW-1:0] sy   // vertical screen position
     );
@@ -57,7 +57,7 @@ module display_24x18 #(
     always_ff @(posedge clk_pix) begin
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
-        line  <= (y >= VA_STA && x == H_STA);
+        line  <= (x == H_STA);
         if (rst) begin
             de <= 0;
             frame <= 0;

--- a/lib/display/display_480p.sv
+++ b/lib/display/display_480p.sv
@@ -24,7 +24,7 @@ module display_480p #(
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
     output      logic frame,    // high at start of frame
-    output      logic line,     // high at start of active line
+    output      logic line,     // high at start of line
     output      logic signed [CORDW-1:0] sx,  // horizontal screen position
     output      logic signed [CORDW-1:0] sy   // vertical screen position
     );
@@ -57,7 +57,7 @@ module display_480p #(
     always_ff @(posedge clk_pix) begin
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
-        line  <= (y >= VA_STA && x == H_STA);
+        line  <= (x == H_STA);
         if (rst) begin
             de <= 0;
             frame <= 0;

--- a/lib/display/display_720p.sv
+++ b/lib/display/display_720p.sv
@@ -24,7 +24,7 @@ module display_720p #(
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
     output      logic frame,    // high at start of frame
-    output      logic line,     // high at start of active line
+    output      logic line,     // high at start of line
     output      logic signed [CORDW-1:0] sx,  // horizontal screen position
     output      logic signed [CORDW-1:0] sy   // vertical screen position
     );
@@ -57,7 +57,7 @@ module display_720p #(
     always_ff @(posedge clk_pix) begin
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
-        line  <= (y >= VA_STA && x == H_STA);
+        line  <= (x == H_STA);
         if (rst) begin
             de <= 0;
             frame <= 0;


### PR DESCRIPTION
The previous display controllers only emitted `line` signals on active lines (i.e. not in blanking). 

However, you often want to draw something part outside the active display area, which makes this restriction unhelpful. The new version emits a line signal on every line. It's easy to test for active lines with `line && de` if you still want that.
