### PR TITLE
Display controller rst pix

### DIFF
--- a/graphics/2d-shapes/ice40/top_castle.sv
+++ b/graphics/2d-shapes/ice40/top_castle.sv
@@ -34,7 +34,7 @@ module top_castle (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_circles.sv
+++ b/graphics/2d-shapes/ice40/top_circles.sv
@@ -34,7 +34,7 @@ module top_circles (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_cube_fill.sv
+++ b/graphics/2d-shapes/ice40/top_cube_fill.sv
@@ -34,7 +34,7 @@ module top_cube_fill (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_rainbow.sv
+++ b/graphics/2d-shapes/ice40/top_rainbow.sv
@@ -34,7 +34,7 @@ module top_rainbow (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_rectangles.sv
+++ b/graphics/2d-shapes/ice40/top_rectangles.sv
@@ -34,7 +34,7 @@ module top_rectangles (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_rectangles_fill.sv
+++ b/graphics/2d-shapes/ice40/top_rectangles_fill.sv
@@ -34,7 +34,7 @@ module top_rectangles_fill (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/ice40/top_triangles_fill.sv
+++ b/graphics/2d-shapes/ice40/top_triangles_fill.sv
@@ -34,7 +34,7 @@ module top_triangles_fill (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7-hd/top_castle.sv
+++ b/graphics/2d-shapes/xc7-hd/top_castle.sv
@@ -37,7 +37,7 @@ module top_castle (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/2d-shapes/xc7-hd/top_circles.sv
+++ b/graphics/2d-shapes/xc7-hd/top_circles.sv
@@ -36,7 +36,7 @@ module top_circles (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7-hd/top_cube_fill.sv
+++ b/graphics/2d-shapes/xc7-hd/top_cube_fill.sv
@@ -36,7 +36,7 @@ module top_cube_fill (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7-hd/top_rainbow.sv
+++ b/graphics/2d-shapes/xc7-hd/top_rainbow.sv
@@ -36,7 +36,7 @@ module top_rainbow (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7-hd/top_rectangles.sv
+++ b/graphics/2d-shapes/xc7-hd/top_rectangles.sv
@@ -36,7 +36,7 @@ module top_rectangles (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7-hd/top_rectangles_fill.sv
+++ b/graphics/2d-shapes/xc7-hd/top_rectangles_fill.sv
@@ -36,7 +36,7 @@ module top_rectangles_fill (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7-hd/top_triangles_fill.sv
+++ b/graphics/2d-shapes/xc7-hd/top_triangles_fill.sv
@@ -36,7 +36,7 @@ module top_triangles_fill (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/2d-shapes/xc7/top_castle.sv
+++ b/graphics/2d-shapes/xc7/top_castle.sv
@@ -32,7 +32,7 @@ module top_castle (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_circles.sv
+++ b/graphics/2d-shapes/xc7/top_circles.sv
@@ -32,7 +32,7 @@ module top_circles (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_cube_fill.sv
+++ b/graphics/2d-shapes/xc7/top_cube_fill.sv
@@ -32,7 +32,7 @@ module top_cube_fill (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_rainbow.sv
+++ b/graphics/2d-shapes/xc7/top_rainbow.sv
@@ -32,7 +32,7 @@ module top_rainbow (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_rectangles.sv
+++ b/graphics/2d-shapes/xc7/top_rectangles.sv
@@ -32,7 +32,7 @@ module top_rectangles (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_rectangles_fill.sv
+++ b/graphics/2d-shapes/xc7/top_rectangles_fill.sv
@@ -32,7 +32,7 @@ module top_rectangles_fill (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/2d-shapes/xc7/top_triangles_fill.sv
+++ b/graphics/2d-shapes/xc7/top_triangles_fill.sv
@@ -32,7 +32,7 @@ module top_triangles_fill (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_greet.sv
+++ b/graphics/ad-astra/ice40/top_greet.sv
@@ -34,7 +34,7 @@ module top_greet (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_greet_v1.sv
+++ b/graphics/ad-astra/ice40/top_greet_v1.sv
@@ -34,7 +34,7 @@ module top_greet_v1 (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_hello_en.sv
+++ b/graphics/ad-astra/ice40/top_hello_en.sv
@@ -34,7 +34,7 @@ module top_hello_en (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_hello_jp.sv
+++ b/graphics/ad-astra/ice40/top_hello_jp.sv
@@ -34,7 +34,7 @@ module top_hello_jp (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_lfsr.sv
+++ b/graphics/ad-astra/ice40/top_lfsr.sv
@@ -34,7 +34,7 @@ module top_lfsr (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_space_f.sv
+++ b/graphics/ad-astra/ice40/top_space_f.sv
@@ -34,7 +34,7 @@ module top_space_f (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/ice40/top_starfields.sv
+++ b/graphics/ad-astra/ice40/top_starfields.sv
@@ -33,7 +33,7 @@ module top_starfields (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/ad-astra/xc7-hd/top_greet.sv
+++ b/graphics/ad-astra/xc7-hd/top_greet.sv
@@ -37,7 +37,7 @@ module top_greet (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_greet_v1.sv
+++ b/graphics/ad-astra/xc7-hd/top_greet_v1.sv
@@ -37,7 +37,7 @@ module top_greet_v1 (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_hello_en.sv
+++ b/graphics/ad-astra/xc7-hd/top_hello_en.sv
@@ -37,7 +37,7 @@ module top_hello_en (
     logic de, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_hello_jp.sv
+++ b/graphics/ad-astra/xc7-hd/top_hello_jp.sv
@@ -37,7 +37,7 @@ module top_hello_jp (
     logic de, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_lfsr.sv
+++ b/graphics/ad-astra/xc7-hd/top_lfsr.sv
@@ -37,7 +37,7 @@ module top_lfsr (
     logic de;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_space_f.sv
+++ b/graphics/ad-astra/xc7-hd/top_space_f.sv
@@ -37,7 +37,7 @@ module top_space_f (
     logic de, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7-hd/top_starfields.sv
+++ b/graphics/ad-astra/xc7-hd/top_starfields.sv
@@ -36,7 +36,7 @@ module top_starfields (
     logic de;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/ad-astra/xc7/top_greet.sv
+++ b/graphics/ad-astra/xc7/top_greet.sv
@@ -32,7 +32,7 @@ module top_greet (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_greet_v1.sv
+++ b/graphics/ad-astra/xc7/top_greet_v1.sv
@@ -32,7 +32,7 @@ module top_greet_v1 (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_hello_en.sv
+++ b/graphics/ad-astra/xc7/top_hello_en.sv
@@ -32,7 +32,7 @@ module top_hello_en (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_hello_jp.sv
+++ b/graphics/ad-astra/xc7/top_hello_jp.sv
@@ -32,7 +32,7 @@ module top_hello_jp (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_lfsr.sv
+++ b/graphics/ad-astra/xc7/top_lfsr.sv
@@ -32,7 +32,7 @@ module top_lfsr (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_space_f.sv
+++ b/graphics/ad-astra/xc7/top_space_f.sv
@@ -32,7 +32,7 @@ module top_space_f (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/ad-astra/xc7/top_starfields.sv
+++ b/graphics/ad-astra/xc7/top_starfields.sv
@@ -31,7 +31,7 @@ module top_starfields (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7-hd/top_cube_pieces.sv
+++ b/graphics/animated-shapes/xc7-hd/top_cube_pieces.sv
@@ -36,7 +36,7 @@ module top_cube_pieces (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7-hd/top_db_bounce.sv
+++ b/graphics/animated-shapes/xc7-hd/top_db_bounce.sv
@@ -36,7 +36,7 @@ module top_db_bounce (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7-hd/top_rotate.sv
+++ b/graphics/animated-shapes/xc7-hd/top_rotate.sv
@@ -38,7 +38,7 @@ module top_rotate (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7-hd/top_sb_bounce.sv
+++ b/graphics/animated-shapes/xc7-hd/top_sb_bounce.sv
@@ -36,7 +36,7 @@ module top_sb_bounce (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7-hd/top_teleport.sv
+++ b/graphics/animated-shapes/xc7-hd/top_teleport.sv
@@ -36,7 +36,7 @@ module top_teleport (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/animated-shapes/xc7/top_cube_pieces.sv
+++ b/graphics/animated-shapes/xc7/top_cube_pieces.sv
@@ -32,7 +32,7 @@ module top_cube_pieces (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/animated-shapes/xc7/top_db_bounce.sv
+++ b/graphics/animated-shapes/xc7/top_db_bounce.sv
@@ -32,7 +32,7 @@ module top_db_bounce (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/animated-shapes/xc7/top_rotate.sv
+++ b/graphics/animated-shapes/xc7/top_rotate.sv
@@ -34,7 +34,7 @@ module top_rotate (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/animated-shapes/xc7/top_sb_bounce.sv
+++ b/graphics/animated-shapes/xc7/top_sb_bounce.sv
@@ -32,7 +32,7 @@ module top_sb_bounce (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/animated-shapes/xc7/top_teleport.sv
+++ b/graphics/animated-shapes/xc7/top_teleport.sv
@@ -32,7 +32,7 @@ module top_teleport (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/ice40/top_david.sv
+++ b/graphics/framebuffers/ice40/top_david.sv
@@ -33,7 +33,7 @@ module top_david (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/framebuffers/ice40/top_david_v1.sv
+++ b/graphics/framebuffers/ice40/top_david_v1.sv
@@ -34,7 +34,7 @@ module top_david_v1 (
     logic de, frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/ice40/top_david_v2.sv
+++ b/graphics/framebuffers/ice40/top_david_v2.sv
@@ -34,7 +34,7 @@ module top_david_v2 (
     logic de, frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/ice40/top_david_v3.sv
+++ b/graphics/framebuffers/ice40/top_david_v3.sv
@@ -34,7 +34,7 @@ module top_david_v3 (
     logic de, frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/ice40/top_line.sv
+++ b/graphics/framebuffers/ice40/top_line.sv
@@ -34,7 +34,7 @@ module top_line (
     logic de, frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7-hd/top_david.sv
+++ b/graphics/framebuffers/xc7-hd/top_david.sv
@@ -37,7 +37,7 @@ module top_david (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7-hd/top_david_v1.sv
+++ b/graphics/framebuffers/xc7-hd/top_david_v1.sv
@@ -37,7 +37,7 @@ module top_david_v1 (
     logic de, frame;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7-hd/top_david_v2.sv
+++ b/graphics/framebuffers/xc7-hd/top_david_v2.sv
@@ -37,7 +37,7 @@ module top_david_v2 (
     logic de, frame;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7-hd/top_david_v3.sv
+++ b/graphics/framebuffers/xc7-hd/top_david_v3.sv
@@ -37,7 +37,7 @@ module top_david_v3 (
     logic de, frame;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7-hd/top_line.sv
+++ b/graphics/framebuffers/xc7-hd/top_line.sv
@@ -37,7 +37,7 @@ module top_line (
     logic de, frame;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7/top_david.sv
+++ b/graphics/framebuffers/xc7/top_david.sv
@@ -31,7 +31,7 @@ module top_david (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/framebuffers/xc7/top_david_v1.sv
+++ b/graphics/framebuffers/xc7/top_david_v1.sv
@@ -32,7 +32,7 @@ module top_david_v1 (
     logic frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7/top_david_v2.sv
+++ b/graphics/framebuffers/xc7/top_david_v2.sv
@@ -32,7 +32,7 @@ module top_david_v2 (
     logic frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7/top_david_v3.sv
+++ b/graphics/framebuffers/xc7/top_david_v3.sv
@@ -32,7 +32,7 @@ module top_david_v3 (
     logic de, frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/framebuffers/xc7/top_line.sv
+++ b/graphics/framebuffers/xc7/top_line.sv
@@ -32,7 +32,7 @@ module top_line (
     logic frame;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/ice40/top_hedgehog.sv
+++ b/graphics/hardware-sprites/ice40/top_hedgehog.sv
@@ -34,7 +34,7 @@ module top_hedgehog (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/ice40/top_hedgehog_v1.sv
+++ b/graphics/hardware-sprites/ice40/top_hedgehog_v1.sv
@@ -34,7 +34,7 @@ module top_hedgehog_v1 (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/ice40/top_sprite_v1.sv
+++ b/graphics/hardware-sprites/ice40/top_sprite_v1.sv
@@ -34,7 +34,7 @@ module top_sprite_v1 (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/ice40/top_sprite_v2.sv
+++ b/graphics/hardware-sprites/ice40/top_sprite_v2.sv
@@ -34,7 +34,7 @@ module top_sprite_v2 (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/ice40/top_sprite_v2a.sv
+++ b/graphics/hardware-sprites/ice40/top_sprite_v2a.sv
@@ -34,7 +34,7 @@ module top_sprite_v2a (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7-hd/top_hedgehog.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_hedgehog.sv
@@ -37,7 +37,7 @@ module top_hedgehog (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),  // wait for clock lock
+        .rst_pix(!clk_pix_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7-hd/top_hedgehog_v1.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_hedgehog_v1.sv
@@ -37,7 +37,7 @@ module top_hedgehog_v1 (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),  // wait for clock lock
+        .rst_pix(!clk_pix_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7-hd/top_sprite_v1.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_sprite_v1.sv
@@ -37,7 +37,7 @@ module top_sprite_v1 (
     logic de, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),  // wait for clock lock
+        .rst_pix(!clk_pix_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7-hd/top_sprite_v2.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_sprite_v2.sv
@@ -37,7 +37,7 @@ module top_sprite_v2 (
     logic de, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),  // wait for clock lock
+        .rst_pix(!clk_pix_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7-hd/top_sprite_v2a.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_sprite_v2a.sv
@@ -37,7 +37,7 @@ module top_sprite_v2a (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),  // wait for clock lock
+        .rst_pix(!clk_pix_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7/top_hedgehog.sv
+++ b/graphics/hardware-sprites/xc7/top_hedgehog.sv
@@ -32,7 +32,7 @@ module top_hedgehog (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7/top_hedgehog_v1.sv
+++ b/graphics/hardware-sprites/xc7/top_hedgehog_v1.sv
@@ -32,7 +32,7 @@ module top_hedgehog_v1 (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7/top_sprite_v1.sv
+++ b/graphics/hardware-sprites/xc7/top_sprite_v1.sv
@@ -32,7 +32,7 @@ module top_sprite_v1 (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7/top_sprite_v2.sv
+++ b/graphics/hardware-sprites/xc7/top_sprite_v2.sv
@@ -32,7 +32,7 @@ module top_sprite_v2 (
     logic de, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/hardware-sprites/xc7/top_sprite_v2a.sv
+++ b/graphics/hardware-sprites/xc7/top_sprite_v2a.sv
@@ -32,7 +32,7 @@ module top_sprite_v2a (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/graphics/life-on-screen/ice40/top_life.sv
+++ b/graphics/life-on-screen/ice40/top_life.sv
@@ -36,7 +36,7 @@ module top_life (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/life-on-screen/xc7-hd/top_life.sv
+++ b/graphics/life-on-screen/xc7-hd/top_life.sv
@@ -40,7 +40,7 @@ module top_life (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/life-on-screen/xc7/top_life.sv
+++ b/graphics/life-on-screen/xc7/top_life.sv
@@ -34,7 +34,7 @@ module top_life (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/lines-and-triangles/ice40/top_cube.sv
+++ b/graphics/lines-and-triangles/ice40/top_cube.sv
@@ -34,7 +34,7 @@ module top_cube (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/ice40/top_latency_check.sv
+++ b/graphics/lines-and-triangles/ice40/top_latency_check.sv
@@ -34,7 +34,7 @@ module top_latency_check (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/ice40/top_line.sv
+++ b/graphics/lines-and-triangles/ice40/top_line.sv
@@ -34,7 +34,7 @@ module top_line (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/ice40/top_triangles.sv
+++ b/graphics/lines-and-triangles/ice40/top_triangles.sv
@@ -34,7 +34,7 @@ module top_triangles (
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/xc7-hd/top_cube.sv
+++ b/graphics/lines-and-triangles/xc7-hd/top_cube.sv
@@ -36,7 +36,7 @@ module top_cube (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/lines-and-triangles/xc7-hd/top_latency_check.sv
+++ b/graphics/lines-and-triangles/xc7-hd/top_latency_check.sv
@@ -36,7 +36,7 @@ module top_latency_check (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/lines-and-triangles/xc7-hd/top_line.sv
+++ b/graphics/lines-and-triangles/xc7-hd/top_line.sv
@@ -36,7 +36,7 @@ module top_line (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/lines-and-triangles/xc7-hd/top_triangles.sv
+++ b/graphics/lines-and-triangles/xc7-hd/top_triangles.sv
@@ -36,7 +36,7 @@ module top_triangles (
     logic de, frame, line;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         /* verilator lint_off PINCONNECTEMPTY */
         .sx(),
         .sy(),

--- a/graphics/lines-and-triangles/xc7/top_cube.sv
+++ b/graphics/lines-and-triangles/xc7/top_cube.sv
@@ -32,7 +32,7 @@ module top_cube (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/xc7/top_latency_check.sv
+++ b/graphics/lines-and-triangles/xc7/top_latency_check.sv
@@ -32,7 +32,7 @@ module top_latency_check (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/xc7/top_line.sv
+++ b/graphics/lines-and-triangles/xc7/top_line.sv
@@ -32,7 +32,7 @@ module top_line (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/graphics/lines-and-triangles/xc7/top_triangles.sv
+++ b/graphics/lines-and-triangles/xc7/top_triangles.sv
@@ -32,7 +32,7 @@ module top_triangles (
     logic frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/lib/display/display_1080p.sv
+++ b/lib/display/display_1080p.sv
@@ -19,7 +19,7 @@ module display_1080p #(
     V_POL=1      // vertical sync polarity (0:neg, 1:pos)
     ) (
     input  wire logic clk_pix,  // pixel clock
-    input  wire logic rst,      // reset
+    input  wire logic rst_pix,  // reset in pixel clock domain
     output      logic hsync,    // horizontal sync
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
@@ -58,7 +58,7 @@ module display_1080p #(
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
         line  <= (x == H_STA);
-        if (rst) begin
+        if (rst_pix) begin
             de <= 0;
             frame <= 0;
             line <= 0;
@@ -73,7 +73,7 @@ module display_1080p #(
         end else begin
             x <= x + 1;
         end
-        if (rst) begin
+        if (rst_pix) begin
             x <= H_STA;
             y <= V_STA;
         end
@@ -83,7 +83,7 @@ module display_1080p #(
     always_ff @ (posedge clk_pix) begin
         sx <= x;
         sy <= y;
-        if (rst) begin
+        if (rst_pix) begin
             sx <= H_STA;
             sy <= V_STA;
         end

--- a/lib/display/display_24x18.sv
+++ b/lib/display/display_24x18.sv
@@ -19,7 +19,7 @@ module display_24x18 #(
     V_POL=1      // vertical sync polarity (0:neg, 1:pos)
     ) (
     input  wire logic clk_pix,  // pixel clock
-    input  wire logic rst,      // reset
+    input  wire logic rst_pix,  // reset in pixel clock domain
     output      logic hsync,    // horizontal sync
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
@@ -58,7 +58,7 @@ module display_24x18 #(
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
         line  <= (x == H_STA);
-        if (rst) begin
+        if (rst_pix) begin
             de <= 0;
             frame <= 0;
             line <= 0;
@@ -73,7 +73,7 @@ module display_24x18 #(
         end else begin
             x <= x + 1;
         end
-        if (rst) begin
+        if (rst_pix) begin
             x <= H_STA;
             y <= V_STA;
         end
@@ -83,7 +83,7 @@ module display_24x18 #(
     always_ff @ (posedge clk_pix) begin
         sx <= x;
         sy <= y;
-        if (rst) begin
+        if (rst_pix) begin
             sx <= H_STA;
             sy <= V_STA;
         end

--- a/lib/display/display_480p.sv
+++ b/lib/display/display_480p.sv
@@ -19,7 +19,7 @@ module display_480p #(
     V_POL=0      // vertical sync polarity (0:neg, 1:pos)
     ) (
     input  wire logic clk_pix,  // pixel clock
-    input  wire logic rst,      // reset
+    input  wire logic rst_pix,  // reset in pixel clock domain
     output      logic hsync,    // horizontal sync
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
@@ -58,7 +58,7 @@ module display_480p #(
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
         line  <= (x == H_STA);
-        if (rst) begin
+        if (rst_pix) begin
             de <= 0;
             frame <= 0;
             line <= 0;
@@ -73,7 +73,7 @@ module display_480p #(
         end else begin
             x <= x + 1;
         end
-        if (rst) begin
+        if (rst_pix) begin
             x <= H_STA;
             y <= V_STA;
         end
@@ -83,7 +83,7 @@ module display_480p #(
     always_ff @ (posedge clk_pix) begin
         sx <= x;
         sy <= y;
-        if (rst) begin
+        if (rst_pix) begin
             sx <= H_STA;
             sy <= V_STA;
         end

--- a/lib/display/display_720p.sv
+++ b/lib/display/display_720p.sv
@@ -19,7 +19,7 @@ module display_720p #(
     V_POL=1      // vertical sync polarity (0:neg, 1:pos)
     ) (
     input  wire logic clk_pix,  // pixel clock
-    input  wire logic rst,      // reset
+    input  wire logic rst_pix,  // reset in pixel clock domain
     output      logic hsync,    // horizontal sync
     output      logic vsync,    // vertical sync
     output      logic de,       // data enable (low in blanking interval)
@@ -58,7 +58,7 @@ module display_720p #(
         de    <= (y >= VA_STA && x >= HA_STA);
         frame <= (y == V_STA  && x == H_STA);
         line  <= (x == H_STA);
-        if (rst) begin
+        if (rst_pix) begin
             de <= 0;
             frame <= 0;
             line <= 0;
@@ -73,7 +73,7 @@ module display_720p #(
         end else begin
             x <= x + 1;
         end
-        if (rst) begin
+        if (rst_pix) begin
             x <= H_STA;
             y <= V_STA;
         end
@@ -83,7 +83,7 @@ module display_720p #(
     always_ff @ (posedge clk_pix) begin
         sx <= x;
         sy <= y;
-        if (rst) begin
+        if (rst_pix) begin
             sx <= H_STA;
             sy <= V_STA;
         end

--- a/lib/display/xc7/display_480p_tb.sv
+++ b/lib/display/xc7/display_480p_tb.sv
@@ -29,7 +29,7 @@ module display_480p_tb();
     logic de, frame, line;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),  // wait for clock lock
+        .rst_pix(!clk_locked),  // wait for clock lock
         .sx,
         .sy,
         .hsync,

--- a/maths/demo/ice40/top_graphing.sv
+++ b/maths/demo/ice40/top_graphing.sv
@@ -34,7 +34,7 @@ module top_graphing (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,

--- a/maths/demo/sim/top_graphing.sv
+++ b/maths/demo/sim/top_graphing.sv
@@ -20,7 +20,7 @@ module top_graphing #(parameter CORDW=16) (   // coordinate width (in bits)
     // display sync signals and coordinates
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst,
+        .rst_pix(rst),
         .sx,
         .sy,
         /* verilator lint_off PINCONNECTEMPTY */

--- a/maths/demo/xc7-hd/top_graphing.sv
+++ b/maths/demo/xc7-hd/top_graphing.sv
@@ -37,7 +37,7 @@ module top_graphing (
     logic de;
     display_720p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_pix_locked),
+        .rst_pix(!clk_pix_locked),
         .sx,
         .sy,
         .hsync,

--- a/maths/demo/xc7/top_graphing.sv
+++ b/maths/demo/xc7/top_graphing.sv
@@ -32,7 +32,7 @@ module top_graphing (
     logic de;
     display_480p #(.CORDW(CORDW)) display_inst (
         .clk_pix,
-        .rst(!clk_locked),
+        .rst_pix(!clk_locked),
         .sx,
         .sy,
         .hsync,


### PR DESCRIPTION
Display controller now uses `.rst_pix` to match `.clk_pix`.