### PR TITLE
Verilator Update

### DIFF
--- a/demos/castle-drawing/README.md
+++ b/demos/castle-drawing/README.md
@@ -20,7 +20,16 @@ source ./create_project.tcl
 
 You can then build `top_castle` as you would for any Vivado project.
 
-## Verilator Build
+## Verilator
+
+### Tested Versions
+
+This simulation have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
+### Verilator Build
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](https://projectf.io/posts/verilog-sim-verilator-sdl/#installing-dependencies).
 

--- a/demos/castle-drawing/sim/Makefile
+++ b/demos/castle-drawing/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Castle Drawing- Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/castle-drawing/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -18,8 +18,9 @@ castle: castle.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. ${PROJF_LIBS} -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: castle
 

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -62,7 +62,16 @@ This demo uses four Mandelbrot module instances for supersampling, plus one DSP 
 
 Learn more from [Multiplication with FPGA DSPs](https://projectf.io/posts/multiplication-fpga-dsps/).
 
-## Verilator Build
+## Verilator
+
+### Tested Versions
+
+This simulation have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
+### Verilator Build
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](https://projectf.io/posts/verilog-sim-verilator-sdl/#installing-dependencies).
 

--- a/demos/mandelbrot/mandelbrot.sv
+++ b/demos/mandelbrot/mandelbrot.sv
@@ -45,7 +45,9 @@ module mandelbrot #(
         .val(mul_val)
     );
 
+    /* verilator lint_off UNUSED */
     logic signed [FP_WIDTH-1:0] xt, xy2;  // temporaries
+    /* verilator lint_on UNUSED */
 
     enum {IDLE, STEP1, STEP2, STEP2A, STEP3, STEP4} state;
     always_ff @(posedge clk) begin

--- a/demos/mandelbrot/mandelbrot.sv
+++ b/demos/mandelbrot/mandelbrot.sv
@@ -45,9 +45,7 @@ module mandelbrot #(
         .val(mul_val)
     );
 
-    /* verilator lint_off UNUSEDSIGNAL */
     logic signed [FP_WIDTH-1:0] xt, xy2;  // temporaries
-    /* verilator lint_on UNUSEDSIGNAL */
 
     enum {IDLE, STEP1, STEP2, STEP2A, STEP3, STEP4} state;
     always_ff @(posedge clk) begin

--- a/demos/mandelbrot/render_mandel.sv
+++ b/demos/mandelbrot/render_mandel.sv
@@ -116,7 +116,7 @@ module render_mandel #(
                 fy <= y_start;
                 busy <= 1;
                 /* verilator lint_off WIDTH */
-                $display("Render start   : (%f,%f)  step: %f  iter max: %d", $itor(fx)*SF, $itor(fy)*SF, $itor(step)*SF, ITER_MAX);
+                $display("Render start   : (%f,%f)  step: %f  iter max: %d", $itor(x_start)*SF, $itor(y_start)*SF, $itor(step)*SF, ITER_MAX);
                 /* verilator lint_on WIDTH */
             end
         endcase

--- a/demos/mandelbrot/render_mandel.sv
+++ b/demos/mandelbrot/render_mandel.sv
@@ -104,7 +104,9 @@ module render_mandel #(
             end
             DONE: begin
                 state <= IDLE;
+                /* verilator lint_off WIDTH */
                 $display("       complete: (%f,%f)", $itor(fx)*SF, $itor(fy)*SF);
+                /* verilator lint_on WIDTH */
             end
             default: if (start) begin  // IDLE
                 state <= INIT;
@@ -113,7 +115,9 @@ module render_mandel #(
                 fx <= x_start;
                 fy <= y_start;
                 busy <= 1;
+                /* verilator lint_off WIDTH */
                 $display("Render start   : (%f,%f)  step: %f  iter max: %d", $itor(fx)*SF, $itor(fy)*SF, $itor(step)*SF, ITER_MAX);
+                /* verilator lint_on WIDTH */
             end
         endcase
         if (rst) begin

--- a/demos/mandelbrot/render_mandel.sv
+++ b/demos/mandelbrot/render_mandel.sv
@@ -104,7 +104,7 @@ module render_mandel #(
             end
             DONE: begin
                 state <= IDLE;
-                $strobe("       complete: (%f,%f)", $itor(fx)*SF, $itor(fy)*SF);
+                $display("       complete: (%f,%f)", $itor(fx)*SF, $itor(fy)*SF);
             end
             default: if (start) begin  // IDLE
                 state <= INIT;
@@ -113,7 +113,7 @@ module render_mandel #(
                 fx <= x_start;
                 fy <= y_start;
                 busy <= 1;
-                $strobe("Render start   : (%f,%f)  step: %f  iter max: %d", $itor(fx)*SF, $itor(fy)*SF, $itor(step)*SF, ITER_MAX);
+                $display("Render start   : (%f,%f)  step: %f  iter max: %d", $itor(fx)*SF, $itor(fy)*SF, $itor(step)*SF, ITER_MAX);
             end
         endcase
         if (rst) begin

--- a/demos/mandelbrot/xc7/top_mandel.sv
+++ b/demos/mandelbrot/xc7/top_mandel.sv
@@ -346,9 +346,7 @@ module top_mandel (
     // paint screen
     logic paint_area;  // high in area of screen to paint
     logic [COLRW-1:0] paint_colr;
-    /* verilator lint_off UNUSEDSIGNAL */
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
-    /* verilator lint_on UNUSEDSIGNAL */
     always_comb begin
         paint_colr = {lb_colr_out_2, lb_colr_out, lb_colr_out};
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY

--- a/demos/mandelbrot/xc7/top_mandel.sv
+++ b/demos/mandelbrot/xc7/top_mandel.sv
@@ -346,7 +346,9 @@ module top_mandel (
     // paint screen
     logic paint_area;  // high in area of screen to paint
     logic [COLRW-1:0] paint_colr;
+    /* verilator lint_off UNUSED */
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
+    /* verilator lint_on UNUSED */
     always_comb begin
         paint_colr = {lb_colr_out_2, lb_colr_out, lb_colr_out};
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY

--- a/demos/rasterbars/README.md
+++ b/demos/rasterbars/README.md
@@ -20,7 +20,16 @@ source ./create_project.tcl
 
 You can then build `top_rasterbars` as you would for any Vivado project.
 
-## Verilator Build
+## Verilator
+
+### Tested Versions
+
+This simulation have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
+### Verilator Build
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](https://projectf.io/posts/verilog-sim-verilator-sdl/#installing-dependencies).
 

--- a/demos/rasterbars/sim/Makefile
+++ b/demos/rasterbars/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Rasterbars - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/rasterbars/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -19,9 +19,9 @@ rasterbars: rasterbars.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I../ ${PROJF_LIBS} \
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
 	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: rasterbars
 

--- a/demos/sinescroll/README.md
+++ b/demos/sinescroll/README.md
@@ -20,7 +20,16 @@ source ./create_project.tcl
 
 You can then build `top_sinescroll` as you would for any Vivado project.
 
-## Verilator Build
+## Verilator
+
+### Tested Versions
+
+This simulation have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
+### Verilator Build
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](https://projectf.io/posts/verilog-sim-verilator-sdl/#installing-dependencies).
 

--- a/demos/sinescroll/sim/Makefile
+++ b/demos/sinescroll/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Sine Scroller - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/sinescroll/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -19,9 +19,9 @@ sinescroll: sinescroll.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I../ ${PROJF_LIBS} \
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
 	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: sinescroll
 

--- a/graphics/2d-shapes/sim/Makefile
+++ b/graphics/2d-shapes/sim/Makefile
@@ -1,11 +1,11 @@
 ## Project F: 2D Shapes - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-shapes/
 
 # render module version
 RENDER_MODS = '320x180'
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -21,9 +21,9 @@ demo: demo.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
+	verilator ${VFLAGS} -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
 	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: demo
 

--- a/graphics/2d-shapes/sim/README.md
+++ b/graphics/2d-shapes/sim/README.md
@@ -18,7 +18,7 @@ _Filled circles drawn by sim demo._
 
 ## Tested Versions
 
-These simulations have been tested with:
+This simulation has been tested with:
 
 * Verilator 4.038 (Ubuntu 22.04 amd64)
 * Verilator 5.006 (macOS 13 arm64)

--- a/graphics/2d-shapes/sim/README.md
+++ b/graphics/2d-shapes/sim/README.md
@@ -16,6 +16,13 @@ There is one demo top module that can draw different things.
 
 _Filled circles drawn by sim demo._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/animated-shapes/sim/Makefile
+++ b/graphics/animated-shapes/sim/Makefile
@@ -1,11 +1,11 @@
 ## Project F: Animated Shapes - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/animated-shapes/
 
 # render module version
 RENDER_MODS = '320x180'
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -22,9 +22,9 @@ demo_sb: demo_sb.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
+	verilator ${VFLAGS} -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
 	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: demo demo_sb
 

--- a/graphics/animated-shapes/sim/README.md
+++ b/graphics/animated-shapes/sim/README.md
@@ -21,6 +21,13 @@ To switch between the different demos, change the render instance near line 155 
 * `render_cube_shatter` - shatter 3D cube drawn from six triangles
 * `render_teleport` - teleport effect with nested squares
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/fpga-graphics/sim/Makefile
+++ b/graphics/fpga-graphics/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: FPGA Graphics - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-graphics/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -15,8 +15,9 @@ colour: colour.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. \
+		-cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: square flag_ethiopia flag_sweden colour
 

--- a/graphics/fpga-graphics/sim/README.md
+++ b/graphics/fpga-graphics/sim/README.md
@@ -19,6 +19,13 @@ If you have a dev board, see the main [Beginning FPGA Graphics README](../README
 
 _Traditional flag of Ethiopia running as a Verilator simulation._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/framebuffers/sim/Makefile
+++ b/graphics/framebuffers/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Framebuffers - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/framebuffers/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -21,8 +21,9 @@ david_fizzle: david_fizzle.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. ${PROJF_LIBS} -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: david_mono david_16colr david_scale david_fizzle
 

--- a/graphics/framebuffers/sim/README.md
+++ b/graphics/framebuffers/sim/README.md
@@ -21,6 +21,13 @@ All based on an image of David by Michelangelo.
 
 _David by Michelangelo with fizzle fade from david\_fizzle simulation._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/hardware-sprites/sim/Makefile
+++ b/graphics/hardware-sprites/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Hardware Sprites - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/hardware-sprites/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -21,8 +21,9 @@ hedgehog: hedgehog.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. ${PROJF_LIBS} -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: tinyf_inline tinyf_rom tinyf_scale tinyf_move hourglass hedgehog
 

--- a/graphics/hardware-sprites/sim/README.md
+++ b/graphics/hardware-sprites/sim/README.md
@@ -22,6 +22,13 @@ If you have a dev board, see the main [Hardware Sprites README](../README.md) fo
 
 _Hedgehog sprite video capture from Nexys Video._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/lines-and-triangles/sim/Makefile
+++ b/graphics/lines-and-triangles/sim/Makefile
@@ -1,11 +1,11 @@
 ## Project F: Lines and Triangles - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/lines-and-triangles/
 
 # render module version
 RENDER_MODS = '320x180'
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -21,9 +21,9 @@ demo: demo.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
+	verilator ${VFLAGS} -I.. -I../${RENDER_MODS} ${PROJF_LIBS} \
 	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: demo
 

--- a/graphics/lines-and-triangles/sim/README.md
+++ b/graphics/lines-and-triangles/sim/README.md
@@ -16,6 +16,13 @@ There is one demo that can draw a line, cube, or triangles.
 
 _Triangles drawn by sim demo._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/lines-and-triangles/sim/README.md
+++ b/graphics/lines-and-triangles/sim/README.md
@@ -18,7 +18,7 @@ _Triangles drawn by sim demo._
 
 ## Tested Versions
 
-These simulations have been tested with:
+This simulation has been tested with:
 
 * Verilator 4.038 (Ubuntu 22.04 amd64)
 * Verilator 5.006 (macOS 13 arm64)

--- a/graphics/pong/sim/Makefile
+++ b/graphics/pong/sim/Makefile
@@ -1,13 +1,13 @@
 ## Project F: FPGA Pong - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-pong/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
 # Project F Library Path
-PATH_LIB = ../../../lib/essential
+PROJF_LIBS = -I../../../lib/essential
 
 pong: pong.exe
 
@@ -15,8 +15,9 @@ pong: pong.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -I${PATH_LIB} -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: pong
 

--- a/graphics/pong/sim/README.md
+++ b/graphics/pong/sim/README.md
@@ -12,6 +12,13 @@ If you have a dev board, see the main [FPGA Pong README](../README.md) for build
 
 _Pong running as a Verilator simulation on macOS._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).

--- a/graphics/pong/sim/README.md
+++ b/graphics/pong/sim/README.md
@@ -14,7 +14,7 @@ _Pong running as a Verilator simulation on macOS._
 
 ## Tested Versions
 
-These simulations have been tested with:
+This simulation has been tested with:
 
 * Verilator 4.038 (Ubuntu 22.04 amd64)
 * Verilator 5.006 (macOS 13 arm64)

--- a/graphics/racing-the-beam/sim/Makefile
+++ b/graphics/racing-the-beam/sim/Makefile
@@ -1,8 +1,8 @@
 ## Project F: Racing the Beam - Verilator Sim Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/racing-the-beam/
 
-CFLAGS = -O2
+VFLAGS = -O3 --x-assign fast --x-initial fast --noassert
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 
@@ -16,8 +16,9 @@ bounce: bounce.exe
 	make -C ./obj_dir -f Vtop_$<
 
 %.mk: top_%.sv
-	verilator -I.. -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
-		-CFLAGS "${CFLAGS} ${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
+	verilator ${VFLAGS} -I.. ${PROJF_LIBS} \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+		-CFLAGS "${SDL_CFLAGS}" -LDFLAGS "${SDL_LDFLAGS}"
 
 all: rasterbars hitomezashi hello colour_cycle bounce
 

--- a/graphics/racing-the-beam/sim/README.md
+++ b/graphics/racing-the-beam/sim/README.md
@@ -20,6 +20,13 @@ If you have a dev board, see the main [Racing the Beam README](../README.md) for
 
 _Raster Bars running as a Verilator simulation._
 
+## Tested Versions
+
+These simulations have been tested with:
+
+* Verilator 4.038 (Ubuntu 22.04 amd64)
+* Verilator 5.006 (macOS 13 arm64)
+
 ## Build & Run
 
 If this is the first time you've used Verilator and SDL, you need to [install dependencies](#installing-dependencies).


### PR DESCRIPTION
* Allow Mandelbrot demo to run on Verilator 4.x
* Use latest Verilator Makefile
* Document tested Verilator versions