### PR TITLE
Add Q to quit Verilator/SDL Simulations

### DIFF
--- a/demos/castle-drawing/README.md
+++ b/demos/castle-drawing/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/castle
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/castle-drawing/README.md
+++ b/demos/castle-drawing/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/castle
 ```
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/castle-drawing/README.md
+++ b/demos/castle-drawing/README.md
@@ -47,8 +47,8 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/castle
 ```
 
+You can quit the demo by pressing the **Q** key.
+
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_castle.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.

--- a/demos/castle-drawing/sim/main_castle.cpp
+++ b/demos/castle-drawing/sim/main_castle.cpp
@@ -1,5 +1,5 @@
 // Project F: Castle Drawing - Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/castle-drawing/
 
 #include <stdio.h>

--- a/demos/castle-drawing/sim/main_castle.cpp
+++ b/demos/castle-drawing/sim/main_castle.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_castle* top = new Vtop_castle;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -97,7 +97,7 @@ Verilator controls:
 
 _NB. Controls don't work if rendering is in progress._
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -95,10 +95,10 @@ Verilator controls:
 * **Space Bar** - select mode: horizontal/vertical/zoom
 * **Down Arrow** - right/down/zoom-in
 
+You can quit the demo by pressing the **Q** key.
+
 _NB. Controls don't work if rendering is in progress._
 
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_mandelbrot.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -95,9 +95,9 @@ Verilator controls:
 * **Space Bar** - select mode: horizontal/vertical/zoom
 * **Down Arrow** - right/down/zoom-in
 
-You can quit the demo by pressing the **Q** key.
-
 _NB. Controls don't work if rendering is in progress._
+
+You can quit the demo by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -97,7 +97,7 @@ Verilator controls:
 
 _NB. Controls don't work if rendering is in progress._
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/mandelbrot/sim/main_mandel.cpp
+++ b/demos/mandelbrot/sim/main_mandel.cpp
@@ -99,6 +99,8 @@ int main(int argc, char* argv[]) {
                 }
             }
 
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
+
             // update keyboard state
             top->btn_up = keyb_state[SDL_SCANCODE_UP];
             top->btn_dn = keyb_state[SDL_SCANCODE_DOWN];

--- a/demos/mandelbrot/sim/main_mandel.cpp
+++ b/demos/mandelbrot/sim/main_mandel.cpp
@@ -58,6 +58,8 @@ int main(int argc, char* argv[]) {
     // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
     const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
 
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_mandel* top = new Vtop_mandel;
 

--- a/demos/rasterbars/README.md
+++ b/demos/rasterbars/README.md
@@ -47,8 +47,8 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/rasterbars
 ```
 
+You can quit the demo by pressing the **Q** key.
+
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_rasterbars.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.

--- a/demos/rasterbars/README.md
+++ b/demos/rasterbars/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/rasterbars
 ```
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/rasterbars/README.md
+++ b/demos/rasterbars/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/rasterbars
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/rasterbars/sim/main_rasterbars.cpp
+++ b/demos/rasterbars/sim/main_rasterbars.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_rasterbars* top = new Vtop_rasterbars;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/demos/rasterbars/sim/main_rasterbars.cpp
+++ b/demos/rasterbars/sim/main_rasterbars.cpp
@@ -1,5 +1,5 @@
 // Project F: Rasterbars Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/rasterbars/
 
 #include <stdio.h>

--- a/demos/sinescroll/README.md
+++ b/demos/sinescroll/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/sinescroll
 ```
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/sinescroll/README.md
+++ b/demos/sinescroll/README.md
@@ -47,7 +47,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/sinescroll
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ### Fullscreen Mode
 

--- a/demos/sinescroll/README.md
+++ b/demos/sinescroll/README.md
@@ -47,8 +47,8 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/sinescroll
 ```
 
+You can quit the demo by pressing the **Q** key.
+
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_sinescroll.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.

--- a/demos/sinescroll/sim/main_sinescroll.cpp
+++ b/demos/sinescroll/sim/main_sinescroll.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_sinescroll* top = new Vtop_sinescroll;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/demos/sinescroll/sim/main_sinescroll.cpp
+++ b/demos/sinescroll/sim/main_sinescroll.cpp
@@ -1,5 +1,5 @@
 // Project F: Sine Scroller Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/sinescroll/
 
 #include <stdio.h>

--- a/graphics/2d-shapes/sim/README.md
+++ b/graphics/2d-shapes/sim/README.md
@@ -41,6 +41,8 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
+You can quit the demo by pressing the **Q** key.
+
 ### Switching Demo
 
 To switch between the different demos, change the render instance near line 115 in `top_demo`, then rerun make.
@@ -55,8 +57,6 @@ To switch between the different demos, change the render instance near line 115 
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_demo.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.
 
 ## Installing Dependencies
 

--- a/graphics/2d-shapes/sim/README.md
+++ b/graphics/2d-shapes/sim/README.md
@@ -41,7 +41,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ### Switching Demo
 

--- a/graphics/2d-shapes/sim/README.md
+++ b/graphics/2d-shapes/sim/README.md
@@ -41,7 +41,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 ### Switching Demo
 

--- a/graphics/2d-shapes/sim/main_demo.cpp
+++ b/graphics/2d-shapes/sim/main_demo.cpp
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Demo Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 #include <stdio.h>

--- a/graphics/2d-shapes/sim/main_demo.cpp
+++ b/graphics/2d-shapes/sim/main_demo.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_demo* top = new Vtop_demo;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/animated-shapes/sim/README.md
+++ b/graphics/animated-shapes/sim/README.md
@@ -46,7 +46,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
-You can quit the demo by pressing the **Q** key.
+You can quit a simulation by pressing the **Q** key.
 
 For the single buffer version, replace `demo` with `demo_sb` in the above instructions.
 

--- a/graphics/animated-shapes/sim/README.md
+++ b/graphics/animated-shapes/sim/README.md
@@ -46,7 +46,7 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 For the single buffer version, replace `demo` with `demo_sb` in the above instructions.
 

--- a/graphics/animated-shapes/sim/README.md
+++ b/graphics/animated-shapes/sim/README.md
@@ -46,13 +46,13 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
+You can quit the demo by pressing the **Q** key.
+
 For the single buffer version, replace `demo` with `demo_sb` in the above instructions.
 
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_demo.cpp` or `main_demo_sb.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.
 
 ## Installing Dependencies
 

--- a/graphics/animated-shapes/sim/main_demo.cpp
+++ b/graphics/animated-shapes/sim/main_demo.cpp
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Double Buffer Demo Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 #include <stdio.h>

--- a/graphics/animated-shapes/sim/main_demo.cpp
+++ b/graphics/animated-shapes/sim/main_demo.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_demo* top = new Vtop_demo;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/animated-shapes/sim/main_demo_sb.cpp
+++ b/graphics/animated-shapes/sim/main_demo_sb.cpp
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Single Buffer Demo Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 #include <stdio.h>

--- a/graphics/animated-shapes/sim/main_demo_sb.cpp
+++ b/graphics/animated-shapes/sim/main_demo_sb.cpp
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_demo_sb* top = new Vtop_demo_sb;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/fpga-graphics/sim/README.md
+++ b/graphics/fpga-graphics/sim/README.md
@@ -50,7 +50,7 @@ Run the simulation executables from `obj_dir`:
 ./obj_dir/square
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 If you want to manually build a simulation, here's an example for 'square':
 

--- a/graphics/fpga-graphics/sim/README.md
+++ b/graphics/fpga-graphics/sim/README.md
@@ -50,6 +50,8 @@ Run the simulation executables from `obj_dir`:
 ./obj_dir/square
 ```
 
+You can quit a simulation by pressing the **Q** key.
+
 If you want to manually build a simulation, here's an example for 'square':
 
 ```shell

--- a/graphics/fpga-graphics/sim/main_colour.cpp
+++ b/graphics/fpga-graphics/sim/main_colour.cpp
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Colour Test Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 #include <stdio.h>

--- a/graphics/fpga-graphics/sim/main_colour.cpp
+++ b/graphics/fpga-graphics/sim/main_colour.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_colour* top = new Vtop_colour;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/fpga-graphics/sim/main_flag_ethiopia.cpp
+++ b/graphics/fpga-graphics/sim/main_flag_ethiopia.cpp
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 #include <stdio.h>

--- a/graphics/fpga-graphics/sim/main_flag_ethiopia.cpp
+++ b/graphics/fpga-graphics/sim/main_flag_ethiopia.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_flag_ethiopia* top = new Vtop_flag_ethiopia;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/fpga-graphics/sim/main_flag_sweden.cpp
+++ b/graphics/fpga-graphics/sim/main_flag_sweden.cpp
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 #include <stdio.h>

--- a/graphics/fpga-graphics/sim/main_flag_sweden.cpp
+++ b/graphics/fpga-graphics/sim/main_flag_sweden.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_flag_sweden* top = new Vtop_flag_sweden;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/fpga-graphics/sim/main_square.cpp
+++ b/graphics/fpga-graphics/sim/main_square.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_square* top = new Vtop_square;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/fpga-graphics/sim/main_square.cpp
+++ b/graphics/fpga-graphics/sim/main_square.cpp
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Square Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 #include <stdio.h>

--- a/graphics/framebuffers/sim/README.md
+++ b/graphics/framebuffers/sim/README.md
@@ -52,6 +52,8 @@ Run the simulation executables from `obj_dir`:
 ./obj_dir/david_scale
 ```
 
+You can quit a simulation by pressing the **Q** key.
+
 ## Installing Dependencies
 
 To build the simulations, you need:

--- a/graphics/framebuffers/sim/README.md
+++ b/graphics/framebuffers/sim/README.md
@@ -52,7 +52,7 @@ Run the simulation executables from `obj_dir`:
 ./obj_dir/david_scale
 ```
 
-You can quit a simulation by pressing the **Q** key.
+You can quit the simulation by pressing the **Q** key.
 
 ## Installing Dependencies
 

--- a/graphics/framebuffers/sim/main_david_16colr.cpp
+++ b/graphics/framebuffers/sim/main_david_16colr.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_david_16colr* top = new Vtop_david_16colr;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/framebuffers/sim/main_david_16colr.cpp
+++ b/graphics/framebuffers/sim/main_david_16colr.cpp
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - 16 Colour David Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 #include <stdio.h>

--- a/graphics/framebuffers/sim/main_david_fizzle.cpp
+++ b/graphics/framebuffers/sim/main_david_fizzle.cpp
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - David Fizzle Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 #include <stdio.h>

--- a/graphics/framebuffers/sim/main_david_fizzle.cpp
+++ b/graphics/framebuffers/sim/main_david_fizzle.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_david_fizzle* top = new Vtop_david_fizzle;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/framebuffers/sim/main_david_mono.cpp
+++ b/graphics/framebuffers/sim/main_david_mono.cpp
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Mono David Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 #include <stdio.h>

--- a/graphics/framebuffers/sim/main_david_mono.cpp
+++ b/graphics/framebuffers/sim/main_david_mono.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_david_mono* top = new Vtop_david_mono;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/framebuffers/sim/main_david_mono_draw.cpp
+++ b/graphics/framebuffers/sim/main_david_mono_draw.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_david_mono_draw* top = new Vtop_david_mono_draw;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/framebuffers/sim/main_david_mono_draw.cpp
+++ b/graphics/framebuffers/sim/main_david_mono_draw.cpp
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Mono David with Drawing Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 #include <stdio.h>

--- a/graphics/framebuffers/sim/main_david_scale.cpp
+++ b/graphics/framebuffers/sim/main_david_scale.cpp
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_david_scale* top = new Vtop_david_scale;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/framebuffers/sim/main_david_scale.cpp
+++ b/graphics/framebuffers/sim/main_david_scale.cpp
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Scaled David Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 #include <stdio.h>

--- a/graphics/hardware-sprites/sim/README.md
+++ b/graphics/hardware-sprites/sim/README.md
@@ -16,7 +16,7 @@ If you have a dev board, see the main [Hardware Sprites README](../README.md) fo
   * Scale - sprite scaling
   * Move - sprite moving
 * Hourglass - 16-colour 8x8 pixel hourglass sprite
-* Hedgehog - 16 colour hedgehog sprite
+* Hedgehog - 16-colour hedgehog sprite
 
 ![](../../../doc/img/hardware-sprites.png?raw=true "")
 
@@ -52,6 +52,8 @@ Run the simulation executables from `obj_dir`:
 ```shell
 ./obj_dir/hedgehog
 ```
+
+You can quit the simulation by pressing the **Q** key.
 
 ## Installing Dependencies
 

--- a/graphics/hardware-sprites/sim/main_hedgehog.cpp
+++ b/graphics/hardware-sprites/sim/main_hedgehog.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - hedgehog Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_hedgehog* top = new Vtop_hedgehog;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/hardware-sprites/sim/main_hourglass.cpp
+++ b/graphics/hardware-sprites/sim/main_hourglass.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hourglass Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_hourglass* top = new Vtop_hourglass;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/hardware-sprites/sim/main_tinyf_inline.cpp
+++ b/graphics/hardware-sprites/sim/main_tinyf_inline.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F Inline Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_tinyf_inline* top = new Vtop_tinyf_inline;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/hardware-sprites/sim/main_tinyf_move.cpp
+++ b/graphics/hardware-sprites/sim/main_tinyf_move.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Motion Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_tinyf_move* top = new Vtop_tinyf_move;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/hardware-sprites/sim/main_tinyf_rom.cpp
+++ b/graphics/hardware-sprites/sim/main_tinyf_rom.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F from ROM Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_tinyf_rom* top = new Vtop_tinyf_rom;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/hardware-sprites/sim/main_tinyf_scale.cpp
+++ b/graphics/hardware-sprites/sim/main_tinyf_scale.cpp
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Scaling Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_tinyf_scale* top = new Vtop_tinyf_scale;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/lines-and-triangles/sim/README.md
+++ b/graphics/lines-and-triangles/sim/README.md
@@ -41,6 +41,8 @@ Run the simulation executable from `obj_dir`:
 ./obj_dir/demo
 ```
 
+You can quit the simulation by pressing the **Q** key.
+
 ### Switching Demo
 
 To switch between the different demos, change the render instance near line 110 in `top_demo`, then rerun make.
@@ -53,8 +55,6 @@ To switch between the different demos, change the render instance near line 110 
 ### Fullscreen Mode
 
 To run in fullscreen mode, edit `main_demo.cpp` so that `FULLSCREEN = true`, then rebuild.
-
-You can quit the demo with the usual key combination: Ctrl-Q on Linux or Command-Q on macOS.
 
 ## Installing Dependencies
 

--- a/graphics/lines-and-triangles/sim/main_demo.cpp
+++ b/graphics/lines-and-triangles/sim/main_demo.cpp
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Demo Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 #include <stdio.h>
@@ -55,6 +55,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_demo* top = new Vtop_demo;
 
@@ -95,6 +100,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/pong/sim/README.md
+++ b/graphics/pong/sim/README.md
@@ -43,6 +43,8 @@ The keyboard controls are:
 * **Space Bar** - start (fire)
 * **Down Arrow** - down
 
+You can quit the simulation by pressing the **Q** key.
+
 You can edit the keyboard controls in `main_pong.cpp`; search for `update keyboard state`.
 
 _Note: this design uses [simple_480p.sv](../simple_480p.sv) and [simple_score.sv](../simple_score.sv) from the main [Pong](../) folder._

--- a/graphics/pong/sim/main_pong.cpp
+++ b/graphics/pong/sim/main_pong.cpp
@@ -1,5 +1,5 @@
 // Project F: FPGA Pong - Pong Game Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-pong/
 
 #include <stdio.h>
@@ -56,6 +56,8 @@ int main(int argc, char* argv[]) {
     // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
     const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
 
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_pong* top = new Vtop_pong;
 
@@ -96,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             // update keyboard state
             top->btn_up = keyb_state[SDL_SCANCODE_UP];

--- a/graphics/racing-the-beam/sim/README.md
+++ b/graphics/racing-the-beam/sim/README.md
@@ -51,6 +51,8 @@ Run the simulation executables from `obj_dir`:
 ./obj_dir/rasterbars
 ```
 
+You can quit the simulation by pressing the **Q** key.
+
 If you want to manually build a simulation, here's an example for 'rasterbars':
 
 ```shell

--- a/graphics/racing-the-beam/sim/main_bounce.cpp
+++ b/graphics/racing-the-beam/sim/main_bounce.cpp
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Bounce Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_bounce* top = new Vtop_bounce;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/racing-the-beam/sim/main_colour_cycle.cpp
+++ b/graphics/racing-the-beam/sim/main_colour_cycle.cpp
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Cycle Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_colour_cycle* top = new Vtop_colour_cycle;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/racing-the-beam/sim/main_hello.cpp
+++ b/graphics/racing-the-beam/sim/main_hello.cpp
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hello Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_hello* top = new Vtop_hello;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/racing-the-beam/sim/main_hitomezashi.cpp
+++ b/graphics/racing-the-beam/sim/main_hitomezashi.cpp
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hitomezashi Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_hitomezashi* top = new Vtop_hitomezashi;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/graphics/racing-the-beam/sim/main_rasterbars.cpp
+++ b/graphics/racing-the-beam/sim/main_rasterbars.cpp
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Raster Bars Verilator C++
-// (C)2022 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_rasterbars* top = new Vtop_rasterbars;
 
@@ -96,6 +101,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);

--- a/maths/demo/sim/README.md
+++ b/maths/demo/sim/README.md
@@ -32,6 +32,8 @@ You can then run the simulation executable from `obj_dir`:
 ./obj_dir/graphing 
 ```
 
+You can quit the simulation by pressing the **Q** key.
+
 # Installing Dependencies
 
 To build the simulations, you need:

--- a/maths/demo/sim/main_graphing.cpp
+++ b/maths/demo/sim/main_graphing.cpp
@@ -1,5 +1,5 @@
 // Project F: Maths Demo - Graphing Verilator C++
-// (C)2021 Will Green, open source software released under the MIT License
+// (C)2023 Will Green, open source software released under the MIT License
 // Learn more at https://projectf.io
 
 #include <stdio.h>
@@ -53,6 +53,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // reference SDL keyboard state array: https://wiki.libsdl.org/SDL_GetKeyboardState
+    const Uint8 *keyb_state = SDL_GetKeyboardState(NULL);
+
+    printf("Simulation running. Press 'Q' in simulation window to quit.\n\n");
+
     // initialize Verilog module
     Vtop_graphing* top = new Vtop_graphing;
 
@@ -93,6 +98,8 @@ int main(int argc, char* argv[]) {
                     break;
                 }
             }
+
+            if (keyb_state[SDL_SCANCODE_Q]) break;  // quit if user presses 'Q'
 
             SDL_UpdateTexture(sdl_texture, NULL, screenbuffer, H_RES*sizeof(Pixel));
             SDL_RenderClear(sdl_renderer);


### PR DESCRIPTION
Linux doesn't have a standard key combo for quitting applications. Add ability to quit any simulation by pressing the 'Q' key. This also works in fullscreen mode.