### PR TITLE
Better Blanking

### DIFF
--- a/demos/mandelbrot/sim/top_mandel.sv
+++ b/demos/mandelbrot/sim/top_mandel.sv
@@ -332,7 +332,7 @@ module top_mandel #(parameter CORDW=16) (  // signed coordinate width (bits)
         paint_colr = {lb_colr_out_2, lb_colr_out, lb_colr_out};
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? paint_colr : 24'h001020;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? paint_colr : 24'h001030;
     end
 
     // SDL output (8 bits per colour channel)

--- a/demos/mandelbrot/xc7/top_mandel.sv
+++ b/demos/mandelbrot/xc7/top_mandel.sv
@@ -353,7 +353,7 @@ module top_mandel (
         paint_colr = {lb_colr_out_2, lb_colr_out, lb_colr_out};
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? paint_colr : 24'h001020;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? paint_colr : 24'h001030;
     end
 
     // VGA Pmod output

--- a/graphics/fpga-graphics/README.md
+++ b/graphics/fpga-graphics/README.md
@@ -28,7 +28,7 @@ _Traditional flag of Ethiopia running as a Verilator simulation._
 
 You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](https://github.com/YosysHQ/icestorm).
 
-You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
+You can get pre-built binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
 
 For example, to build `flag_ethiopia`; clone the projf-explore git repo, then:
 
@@ -49,9 +49,7 @@ If you get the error `Can't find iCE FTDI USB device`, try running `iceprog` wit
 
 The iCE40 designs have been tested with:
 
-* Yosys 0.26
-* nextpnr 0.5
-* IceStorm d20a5e9 (2023-02-18)
+* OSS CAD Suite 2023-03-01
 
 ## Arty Build
 

--- a/graphics/fpga-graphics/README.md
+++ b/graphics/fpga-graphics/README.md
@@ -26,9 +26,9 @@ _Traditional flag of Ethiopia running as a Verilator simulation._
 
 ## iCEBreaker Build
 
-You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](http://bygone.clairexen.net/icestorm/).
+You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](https://github.com/YosysHQ/icestorm).
 
-You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build). If you want to build the tools yourself, check out [Building iCE40 FPGA Toolchain on Linux](https://projectf.io/posts/building-ice40-fpga-toolchain/).
+You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
 
 For example, to build `flag_ethiopia`; clone the projf-explore git repo, then:
 
@@ -45,9 +45,13 @@ iceprog flag_ethiopia.bin
 
 If you get the error `Can't find iCE FTDI USB device`, try running `iceprog` with `sudo`.
 
-### Problems Building
+### Tested Versions
 
-If you have problems building the iCE40 designs, make sure you're using Yosys 0.10 or later.
+The iCE40 designs have been tested with:
+
+* Yosys 0.26
+* nextpnr 0.5
+* IceStorm d20a5e9 (2023-02-18)
 
 ## Arty Build
 
@@ -58,7 +62,13 @@ cd projf-explore/graphics/fpga-graphics/xc7/vivado
 source ./create_project.tcl
 ```
 
-You can then build `top_square`, `top_flag_ethiopia`, `top_flag_sweden`, or `top_colour` as you would for any Vivado project.
+You can then build the designs as you would for any Vivado project.
+
+### Tested Versions
+
+The Arty designs have been tested with:
+
+* Vivado 2022.2
 
 ### Behavioural Simulation
 

--- a/graphics/fpga-graphics/README.md
+++ b/graphics/fpga-graphics/README.md
@@ -9,7 +9,7 @@ File layout:
 * `xc7` - designs for Arty and other Xilinx 7 Series boards
 * `xc7-hd` - experimental designs for Nexys Video and larger Xilinx 7 Series FPGAs
 
-These designs make use of modules from the [Project F library](../../lib/). Check the included iCE40 [Makefile](ice40/Makefile) or Vivado [create_project.tcl](xc7/vivado/create_project.tcl) to see the list of modules used.
+These designs make use of modules from the [Project F library](../../lib/).
 
 ## Demos
 

--- a/graphics/fpga-graphics/ice40/Makefile
+++ b/graphics/fpga-graphics/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: FPGA Graphics - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-graphics/
 
 # configuration

--- a/graphics/fpga-graphics/ice40/icebreaker.pcf
+++ b/graphics/fpga-graphics/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: FPGA Graphics - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-graphics/
 
 ## Board Clock: 12 MHz

--- a/graphics/fpga-graphics/ice40/top_colour.sv
+++ b/graphics/fpga-graphics/ice40/top_colour.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Colour Test (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -41,26 +41,26 @@ module top_colour (
         .de
     );
 
-    // screen dimensions (must match display_inst)
-    localparam H_RES = 640;  // horizontal screen resolution
-    localparam V_RES = 480;  // vertical screen resolution
-
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sx < 256 && sy < 256) begin  // colour square in top-left 256x256 pixels
             paint_r = sx[7:4];  // 16 horizontal pixels of each red level
             paint_g = sy[7:4];  // 16 vertical pixels of each green level
             paint_b = 4'h4;     // constant blue level
-        end else if (sx < H_RES && sy < V_RES) begin  // otherwise dark blue
+        end else begin  // background colour
             paint_r = 4'h0;
             paint_g = 4'h1;
-            paint_b = 4'h2;
-        end else begin  // black in blanking interval
-            paint_r = 4'h0;
-            paint_g = 4'h0;
-            paint_b = 4'h0;
+            paint_b = 4'h3;
         end
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -69,7 +69,7 @@ module top_colour (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/fpga-graphics/ice40/top_flag_ethiopia.sv
+++ b/graphics/fpga-graphics/ice40/top_flag_ethiopia.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -43,7 +43,7 @@ module top_flag_ethiopia (
         .de
     );
 
-    // traditional flag of Ethiopia
+    // paint colour: traditional flag of Ethiopia
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy < 160) begin  // top of flag is green
@@ -61,13 +61,21 @@ module top_flag_ethiopia (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI Pmod output
     SB_IO #(
         .PIN_TYPE(6'b010100)  // PIN_OUTPUT_REGISTERED
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/fpga-graphics/ice40/top_flag_sweden.sv
+++ b/graphics/fpga-graphics/ice40/top_flag_sweden.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Sweden (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -41,7 +41,7 @@ module top_flag_sweden (
         .de
     );
 
-    // flag of Sweden (16:10 ratio)
+    // paint colour: flag of Sweden (16:10 ratio)
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy >= 400) begin  // black outside the flag area
@@ -63,13 +63,21 @@ module top_flag_sweden (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI Pmod output
     SB_IO #(
         .PIN_TYPE(6'b010100)  // PIN_OUTPUT_REGISTERED
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/fpga-graphics/ice40/top_square.sv
+++ b/graphics/fpga-graphics/ice40/top_square.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Square (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -47,12 +47,20 @@ module top_square (
         square = (sx > 220 && sx < 420) && (sy > 140 && sy < 340);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
         paint_g = (square) ? 4'hF : 4'h3;
         paint_b = (square) ? 4'hF : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -61,7 +69,7 @@ module top_square (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/fpga-graphics/lint.sh
+++ b/graphics/fpga-graphics/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Project F: Lint Script
-# (C)2022 Will Green, open source software released under the MIT License
+# (C)2023 Will Green, open source software released under the MIT License
 # Learn more at https://projectf.io/posts/fpga-graphics/
 
 DIR=`dirname $0`

--- a/graphics/fpga-graphics/sim/top_colour.sv
+++ b/graphics/fpga-graphics/sim/top_colour.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Colour Test (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -31,26 +31,26 @@ module top_colour #(parameter CORDW=10) (  // coordinate width
         .de
     );
 
-    // screen dimensions (must match display_inst)
-    localparam H_RES = 640;  // horizontal screen resolution
-    localparam V_RES = 480;  // vertical screen resolution
-
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sx < 256 && sy < 256) begin  // colour square in top-left 256x256 pixels
             paint_r = sx[7:4];  // 16 horizontal pixels of each red level
             paint_g = sy[7:4];  // 16 vertical pixels of each green level
             paint_b = 4'h4;     // constant blue level
-        end else if (sx < H_RES && sy < V_RES) begin  // otherwise dark blue
+        end else begin  // background colour
             paint_r = 4'h0;
             paint_g = 4'h1;
-            paint_b = 4'h2;
-        end else begin  // black in blanking interval
-            paint_r = 4'h0;
-            paint_g = 4'h0;
-            paint_b = 4'h0;
+            paint_b = 4'h3;
         end
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // SDL output (8 bits per colour channel)
@@ -58,8 +58,8 @@ module top_colour #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/fpga-graphics/sim/top_flag_ethiopia.sv
+++ b/graphics/fpga-graphics/sim/top_flag_ethiopia.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -31,7 +31,7 @@ module top_flag_ethiopia #(parameter CORDW=10) (  // coordinate width
         .de
     );
 
-    // traditional flag of Ethiopia
+    // paint colour: traditional flag of Ethiopia
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy < 160) begin  // top of flag is green
@@ -49,13 +49,21 @@ module top_flag_ethiopia #(parameter CORDW=10) (  // coordinate width
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/fpga-graphics/sim/top_flag_sweden.sv
+++ b/graphics/fpga-graphics/sim/top_flag_sweden.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Sweden (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -31,7 +31,7 @@ module top_flag_sweden #(parameter CORDW=10) (  // coordinate width
         .de
     );
 
-    // flag of Sweden (16:10 ratio)
+    // paint colour: flag of Sweden (16:10 ratio)
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy >= 400) begin  // black outside the flag area
@@ -53,13 +53,21 @@ module top_flag_sweden #(parameter CORDW=10) (  // coordinate width
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/fpga-graphics/sim/top_square.sv
+++ b/graphics/fpga-graphics/sim/top_square.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Square (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -37,7 +37,7 @@ module top_square #(parameter CORDW=10) (  // coordinate width
         square = (sx > 220 && sx < 420) && (sy > 140 && sy < 340);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
@@ -45,13 +45,21 @@ module top_square #(parameter CORDW=10) (  // coordinate width
         paint_b = (square) ? 4'hF : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/fpga-graphics/simple_480p.sv
+++ b/graphics/fpga-graphics/simple_480p.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Simple 640x480p60 Display
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none

--- a/graphics/fpga-graphics/simple_720p.sv
+++ b/graphics/fpga-graphics/simple_720p.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Simple 1280x720p60 Display
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none

--- a/graphics/fpga-graphics/xc7-hd/nexys_video.xdc
+++ b/graphics/fpga-graphics/xc7-hd/nexys_video.xdc
@@ -1,5 +1,5 @@
 ## Project F: FPGA Graphics - Nexys Video Board Constraints
-## (C)2022 Will Green, Open source hardware released under the MIT License
+## (C)2023 Will Green, Open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-graphics/
 
 ## FPGA Configuration I/O Options

--- a/graphics/fpga-graphics/xc7-hd/simple_720p_tb.sv
+++ b/graphics/fpga-graphics/xc7-hd/simple_720p_tb.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Simple 1280x720p60 Display Test Bench (XC7)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none

--- a/graphics/fpga-graphics/xc7-hd/top_colour.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_colour.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Colour Test (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -44,26 +44,26 @@ module top_colour (
         .de
     );
 
-    // screen dimensions (must match display_inst)
-    localparam H_RES = 1280;  // horizontal screen resolution
-    localparam V_RES =  720;  // vertical screen resolution
-
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sx < 512 && sy < 512) begin  // colour square in top-left 512x512 pixels
             paint_r = sx[8:5];  // 32 horizontal pixels of each red level
             paint_g = sy[8:5];  // 32 vertical pixels of each green level
             paint_b = 4'h4;     // constant blue level
-        end else if (sx < H_RES && sy < V_RES) begin  // otherwise dark blue
+        end else begin  // background colour
             paint_r = 4'h0;
             paint_g = 4'h1;
-            paint_b = 4'h2;
-        end else begin  // black in blanking interval
-            paint_r = 4'h0;
-            paint_g = 4'h0;
-            paint_b = 4'h0;
+            paint_b = 4'h3;
         end
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -73,9 +73,9 @@ module top_colour (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_colour.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_colour.sv
@@ -72,10 +72,10 @@ module top_colour (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_flag_ethiopia.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_flag_ethiopia.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -46,7 +46,7 @@ module top_flag_ethiopia (
         .de
     );
 
-    // traditional flag of Ethiopia
+    // paint colour: traditional flag of Ethiopia
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy < 240) begin  // top of flag is green
@@ -64,6 +64,14 @@ module top_flag_ethiopia (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI signals (8 bits per colour channel)
     logic [7:0] dvi_r, dvi_g, dvi_b;
     logic dvi_hsync, dvi_vsync, dvi_de;
@@ -71,9 +79,9 @@ module top_flag_ethiopia (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_flag_ethiopia.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_flag_ethiopia.sv
@@ -78,10 +78,10 @@ module top_flag_ethiopia (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_flag_sweden.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_flag_sweden.sv
@@ -80,10 +80,10 @@ module top_flag_sweden (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_flag_sweden.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_flag_sweden.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Sweden (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -44,7 +44,7 @@ module top_flag_sweden (
         .de
     );
 
-    // flag of Sweden (16:10 ratio)
+    // paint colour: flag of Sweden (16:10 ratio)
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy >= 400) begin  // black outside the flag area
@@ -66,6 +66,14 @@ module top_flag_sweden (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI signals (8 bits per colour channel)
     logic [7:0] dvi_r, dvi_g, dvi_b;
     logic dvi_hsync, dvi_vsync, dvi_de;
@@ -73,9 +81,9 @@ module top_flag_sweden (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_square.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_square.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Square (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -50,12 +50,20 @@ module top_square (
         square = (sx > 440 && sx < 840) && (sy > 160 && sy < 560);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
         paint_g = (square) ? 4'hF : 4'h3;
         paint_b = (square) ? 4'hF : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -65,9 +73,9 @@ module top_square (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/top_square.sv
+++ b/graphics/fpga-graphics/xc7-hd/top_square.sv
@@ -72,10 +72,10 @@ module top_square (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/fpga-graphics/xc7-hd/vivado/create_project.tcl
+++ b/graphics/fpga-graphics/xc7-hd/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: FPGA Graphics - Create Vivado Project (Nexys Video)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/fpga-graphics/
 
 puts "INFO: Project F - FPGA Graphics Project Creation Script"

--- a/graphics/fpga-graphics/xc7/arty.xdc
+++ b/graphics/fpga-graphics/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: FPGA Graphics - Arty A7-35T Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-graphics/
 
 ## FPGA Configuration I/O Options

--- a/graphics/fpga-graphics/xc7/simple_480p_tb.sv
+++ b/graphics/fpga-graphics/xc7/simple_480p_tb.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Simple 640x480p60 Display Test Bench (XC7)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none

--- a/graphics/fpga-graphics/xc7/top_colour.sv
+++ b/graphics/fpga-graphics/xc7/top_colour.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Colour Test (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -42,40 +42,34 @@ module top_colour (
         .de
     );
 
-    // screen dimensions (must match display_inst)
-    localparam H_RES = 640;  // horizontal screen resolution
-    localparam V_RES = 480;  // vertical screen resolution
-
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sx < 256 && sy < 256) begin  // colour square in top-left 256x256 pixels
             paint_r = sx[7:4];  // 16 horizontal pixels of each red level
             paint_g = sy[7:4];  // 16 vertical pixels of each green level
             paint_b = 4'h4;     // constant blue level
-        end else if (sx < H_RES && sy < V_RES) begin  // otherwise dark blue
+        end else begin  // background colour
             paint_r = 4'h0;
             paint_g = 4'h1;
-            paint_b = 4'h2;
-        end else begin  // black in blanking interval
-            paint_r = 4'h0;
-            paint_g = 4'h0;
-            paint_b = 4'h0;
+            paint_b = 4'h3;
         end
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/fpga-graphics/xc7/top_flag_ethiopia.sv
+++ b/graphics/fpga-graphics/xc7/top_flag_ethiopia.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Ethiopia (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -44,7 +44,7 @@ module top_flag_ethiopia (
         .de
     );
 
-    // traditional flag of Ethiopia
+    // paint colour: traditional flag of Ethiopia
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy < 160) begin  // top of flag is green
@@ -62,18 +62,20 @@ module top_flag_ethiopia (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/fpga-graphics/xc7/top_flag_sweden.sv
+++ b/graphics/fpga-graphics/xc7/top_flag_sweden.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Flag of Sweden (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -42,7 +42,7 @@ module top_flag_sweden (
         .de
     );
 
-    // flag of Sweden (16:10 ratio)
+    // paint colour: flag of Sweden (16:10 ratio)
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         if (sy >= 400) begin  // black outside the flag area
@@ -64,18 +64,20 @@ module top_flag_sweden (
         end
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/fpga-graphics/xc7/top_square.sv
+++ b/graphics/fpga-graphics/xc7/top_square.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Graphics - Square (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-graphics/
 
 `default_nettype none
@@ -48,7 +48,7 @@ module top_square (
         square = (sx > 220 && sx < 420) && (sy > 140 && sy < 340);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
@@ -56,18 +56,20 @@ module top_square (
         paint_b = (square) ? 4'hF : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/fpga-graphics/xc7/vivado/create_project.tcl
+++ b/graphics/fpga-graphics/xc7/vivado/create_project.tcl
@@ -59,7 +59,6 @@ set_property -name "top_auto_set" -value "0" -objects $fs_design_obj
 # Design sources (used in simulation)
 set design_sources [list \
   [file normalize "${lib_dir}/clock/xc7/clock_480p.sv"] \
-  [file normalize "${lib_dir}/clock/xc7/clock_720p.sv"] \
   [file normalize "${origin_dir}/simple_480p.sv"] \
 ]
 add_files -norecurse -fileset $fs_design_obj $design_sources

--- a/graphics/fpga-graphics/xc7/vivado/create_project.tcl
+++ b/graphics/fpga-graphics/xc7/vivado/create_project.tcl
@@ -59,6 +59,7 @@ set_property -name "top_auto_set" -value "0" -objects $fs_design_obj
 # Design sources (used in simulation)
 set design_sources [list \
   [file normalize "${lib_dir}/clock/xc7/clock_480p.sv"] \
+  [file normalize "${lib_dir}/clock/xc7/clock_720p.sv"] \
   [file normalize "${origin_dir}/simple_480p.sv"] \
 ]
 add_files -norecurse -fileset $fs_design_obj $design_sources

--- a/graphics/hardware-sprites/sprite_inline.sv
+++ b/graphics/hardware-sprites/sprite_inline.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite from Inline Bitmap
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -25,7 +25,7 @@ module sprite_inline #(
     /* verilator lint_off LITENDIAN */
     logic [0:SPR_WIDTH-1] bmap [SPR_HEIGHT];
     /* verilator lint_on LITENDIAN */
-    initial begin  // big endian vector, so we can write initial block left to right
+    initial begin  // MSB first, so we can write initial block left to right
         bmap[0]  = 8'b1111_1100;
         bmap[1]  = 8'b1100_0000;
         bmap[2]  = 8'b1100_0000;

--- a/graphics/pong/simple_score.sv
+++ b/graphics/pong/simple_score.sv
@@ -1,5 +1,5 @@
 // Project F: FPGA Pong - Simple Score Drawing
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-pong/
 
 `default_nettype none
@@ -17,7 +17,7 @@ module simple_score #(
     output      logic pix              // draw pixel at this position?
     );
 
-    // number characters: big-endian vector, so we can write pixels left to right
+    // number characters: MSB first, so we can write pixels left to right
     /* verilator lint_off LITENDIAN */
     logic [0:14] chars [10];  // ten characters of 15 pixels each
     /* verilator lint_on LITENDIAN */

--- a/graphics/racing-the-beam/README.md
+++ b/graphics/racing-the-beam/README.md
@@ -29,7 +29,7 @@ _Raster Bars running as a Verilator simulation._
 
 You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](https://github.com/YosysHQ/icestorm).
 
-You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
+You can get pre-built binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
 
 For example, to build `rasterbars`; clone the projf-explore git repo, then:
 
@@ -50,9 +50,7 @@ If you get the error `Can't find iCE FTDI USB device`, try running `iceprog` wit
 
 The iCE40 designs have been tested with:
 
-* Yosys 0.26
-* nextpnr 0.5
-* IceStorm d20a5e9 (2023-02-18)
+* OSS CAD Suite 2023-03-01
 
 ## Arty Build
 

--- a/graphics/racing-the-beam/README.md
+++ b/graphics/racing-the-beam/README.md
@@ -27,9 +27,9 @@ _Raster Bars running as a Verilator simulation._
 
 ## iCEBreaker Build
 
-You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](http://bygone.clairexen.net/icestorm/).
+You can build projects for [iCEBreaker](https://docs.icebreaker-fpga.org/hardware/icebreaker/) using the included [Makefile](ice40/Makefile) with [Yosys](https://yosyshq.net/yosys/), [nextpnr](https://github.com/YosysHQ/nextpnr), and [IceStorm Tools](https://github.com/YosysHQ/icestorm).
 
-You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build). If you want to build the tools yourself, check out [Building iCE40 FPGA Toolchain on Linux](https://projectf.io/posts/building-ice40-fpga-toolchain/).
+You can get pre-built tool binaries for Linux, Mac, and Windows from [YosysHQ](https://github.com/YosysHQ/oss-cad-suite-build).
 
 For example, to build `rasterbars`; clone the projf-explore git repo, then:
 
@@ -46,9 +46,13 @@ iceprog rasterbars.bin
 
 If you get the error `Can't find iCE FTDI USB device`, try running `iceprog` with `sudo`.
 
-### Problems Building
+### Tested Versions
 
-If you have problems building the iCE40 designs, make sure you're using Yosys 0.10 or later.
+The iCE40 designs have been tested with:
+
+* Yosys 0.26
+* nextpnr 0.5
+* IceStorm d20a5e9 (2023-02-18)
 
 ## Arty Build
 
@@ -59,7 +63,13 @@ cd projf-explore/graphics/racing-the-beam/xc7/vivado
 source ./create_project.tcl
 ```
 
-You can then build the demos as you would for any Vivado project.
+You can then build the designs as you would for any Vivado project.
+
+### Tested Versions
+
+The Arty designs have been tested with:
+
+* Vivado 2022.2
 
 ### Other Xilinx 7 Series Boards
 

--- a/graphics/racing-the-beam/README.md
+++ b/graphics/racing-the-beam/README.md
@@ -9,7 +9,7 @@ File layout:
 * `xc7` - designs for Arty and other Xilinx 7 Series boards
 * `xc7-hd` - experimental designs for Nexys Video and larger Xilinx 7 Series FPGAs
 
-These designs make use of modules from the [Project F library](../../lib/). Check the included iCE40 [Makefile](ice40/Makefile) or Vivado [create_project.tcl](xc7/vivado/create_project.tcl) to see the list of modules used.
+These designs make use of modules from the [Project F library](../../lib/).
 
 ## Demos
 

--- a/graphics/racing-the-beam/ice40/Makefile
+++ b/graphics/racing-the-beam/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: Racing the Beam - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/racing-the-beam/
 
 # configuration

--- a/graphics/racing-the-beam/ice40/icebreaker.pcf
+++ b/graphics/racing-the-beam/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: Racing the Beam - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/racing-the-beam/
 
 ## Board Clock: 12 MHz

--- a/graphics/racing-the-beam/ice40/top_bounce.sv
+++ b/graphics/racing-the-beam/ice40/top_bounce.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Bounce (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -98,12 +98,20 @@ module top_bounce (
         square = (sx >= qx) && (sx < qx + Q_SIZE) && (sy >= qy) && (sy < qy + Q_SIZE);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
         paint_g = (square) ? 4'hF : 4'h3;
         paint_b = (square) ? 4'hF : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -112,7 +120,7 @@ module top_bounce (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/racing-the-beam/ice40/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/ice40/top_colour_cycle.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Cycle (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -61,12 +61,20 @@ module top_colour_cycle (
         end
     end
 
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = sx[7:4];  // 16 horizontal pixels of each red level
         paint_g = sy[7:4];  // 16 vertical pixels of each green level
         paint_b = colr_level;  // blue level changes over time
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -75,7 +83,7 @@ module top_colour_cycle (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/racing-the-beam/ice40/top_hello.sv
+++ b/graphics/racing-the-beam/ice40/top_hello.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hello (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -43,7 +43,7 @@ module top_hello (
         .de
     );
 
-    // bitmap: big-endian vector, so we can write pixels left to right
+    // bitmap: MSB first, so we can write pixels left to right
     /* verilator lint_off LITENDIAN */
     logic [0:19] bmap [15];  // 20 pixels by 15 lines
     /* verilator lint_on LITENDIAN */
@@ -76,12 +76,20 @@ module top_hello (
         picture = de ? bmap[y][x] : 0;  // look up pixel (unless we're in blanking)
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (picture) ? 4'hF : 4'h1;
         paint_g = (picture) ? 4'hC : 4'h3;
         paint_b = (picture) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -90,7 +98,7 @@ module top_hello (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/racing-the-beam/ice40/top_hitomezashi.sv
+++ b/graphics/racing-the-beam/ice40/top_hitomezashi.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hitomezashi (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -43,7 +43,7 @@ module top_hitomezashi (
         .de
     );
 
-    // stitch start values: big-endian vector, so we can write left to right
+    // stitch start values: MSB first, so we can write left to right
     /* verilator lint_off LITENDIAN */
     logic [0:39] v_start;  // 40 vertical lines
     logic [0:29] h_start;  // 30 horizontal lines
@@ -66,12 +66,20 @@ module top_hitomezashi (
         stitch = (v_line && v_on) || (h_line && h_on);
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (stitch) ? 4'hF : 4'h1;
         paint_g = (stitch) ? 4'hC : 4'h3;
         paint_b = (stitch) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -80,7 +88,7 @@ module top_hitomezashi (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/racing-the-beam/ice40/top_rasterbars.sv
+++ b/graphics/racing-the-beam/ice40/top_rasterbars.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Test (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -79,13 +79,21 @@ module top_rasterbars (
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = bar_colr;
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI Pmod output
     SB_IO #(
         .PIN_TYPE(6'b010100)  // PIN_OUTPUT_REGISTERED
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/racing-the-beam/lint.sh
+++ b/graphics/racing-the-beam/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Project F: Lint Script
-# (C)2022 Will Green, open source software released under the MIT License
+# (C)2023 Will Green, open source software released under the MIT License
 # Learn more at https://projectf.io
 
 DIR=`dirname $0`

--- a/graphics/racing-the-beam/sim/top_bounce.sv
+++ b/graphics/racing-the-beam/sim/top_bounce.sv
@@ -109,7 +109,7 @@ module top_bounce #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_r <= {2{display_r}};
         sdl_g <= {2{display_g}};
         sdl_b <= {2{display_b}};
     end

--- a/graphics/racing-the-beam/sim/top_bounce.sv
+++ b/graphics/racing-the-beam/sim/top_bounce.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Bounce (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -88,7 +88,7 @@ module top_bounce #(parameter CORDW=10) (  // coordinate width
         square = (sx >= qx) && (sx < qx + Q_SIZE) && (sy >= qy) && (sy < qy + Q_SIZE);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
@@ -96,13 +96,21 @@ module top_bounce #(parameter CORDW=10) (  // coordinate width
         paint_b = (square) ? 4'hF : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/racing-the-beam/sim/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/sim/top_colour_cycle.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Cycle (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -51,7 +51,7 @@ module top_colour_cycle #(parameter CORDW=10) (  // coordinate width
         end
     end
 
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = sx[7:4];  // 16 horizontal pixels of each red level
@@ -59,13 +59,21 @@ module top_colour_cycle #(parameter CORDW=10) (  // coordinate width
         paint_b = colr_level;  // blue level changes over time
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/racing-the-beam/sim/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/sim/top_colour_cycle.sv
@@ -72,7 +72,7 @@ module top_colour_cycle #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_r <= {2{display_r}};
         sdl_g <= {2{display_g}};
         sdl_b <= {2{display_b}};
     end

--- a/graphics/racing-the-beam/sim/top_hello.sv
+++ b/graphics/racing-the-beam/sim/top_hello.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hello (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -31,7 +31,7 @@ module top_hello #(parameter CORDW=10) (  // coordinate width
         .de
     );
 
-    // bitmap: big-endian vector, so we can write pixels left to right
+    // bitmap: MSB first, so we can write pixels left to right
     /* verilator lint_off LITENDIAN */
     logic [0:19] bmap [15];  // 20 pixels by 15 lines
     /* verilator lint_on LITENDIAN */
@@ -64,7 +64,7 @@ module top_hello #(parameter CORDW=10) (  // coordinate width
         picture = de ? bmap[y][x] : 0;  // look up pixel (unless we're in blanking)
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (picture) ? 4'hF : 4'h1;
@@ -72,13 +72,21 @@ module top_hello #(parameter CORDW=10) (  // coordinate width
         paint_b = (picture) ? 4'h0 : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/racing-the-beam/sim/top_hello.sv
+++ b/graphics/racing-the-beam/sim/top_hello.sv
@@ -85,7 +85,7 @@ module top_hello #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_r <= {2{display_r}};
         sdl_g <= {2{display_g}};
         sdl_b <= {2{display_b}};
     end

--- a/graphics/racing-the-beam/sim/top_hitomezashi.sv
+++ b/graphics/racing-the-beam/sim/top_hitomezashi.sv
@@ -75,7 +75,7 @@ module top_hitomezashi #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_r <= {2{display_r}};
         sdl_g <= {2{display_g}};
         sdl_b <= {2{display_b}};
     end

--- a/graphics/racing-the-beam/sim/top_hitomezashi.sv
+++ b/graphics/racing-the-beam/sim/top_hitomezashi.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hitomezashi (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -31,7 +31,7 @@ module top_hitomezashi #(parameter CORDW=10) (  // coordinate width
         .de
     );
 
-    // stitch start values: big-endian vector, so we can write left to right
+    // stitch start values: MSB first, so we can write left to right
     /* verilator lint_off LITENDIAN */
     logic [0:39] v_start;  // 40 vertical lines
     logic [0:29] h_start;  // 30 horizontal lines
@@ -54,7 +54,7 @@ module top_hitomezashi #(parameter CORDW=10) (  // coordinate width
         stitch = (v_line && v_on) || (h_line && h_on);
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (stitch) ? 4'hF : 4'h1;
@@ -62,13 +62,21 @@ module top_hitomezashi #(parameter CORDW=10) (  // coordinate width
         paint_b = (stitch) ? 4'h0 : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/racing-the-beam/sim/top_rasterbars.sv
+++ b/graphics/racing-the-beam/sim/top_rasterbars.sv
@@ -82,7 +82,7 @@ module top_rasterbars #(parameter CORDW=10) (  // coordinate width
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_r <= {2{display_r}};
         sdl_g <= {2{display_g}};
         sdl_b <= {2{display_b}};
     end

--- a/graphics/racing-the-beam/sim/top_rasterbars.sv
+++ b/graphics/racing-the-beam/sim/top_rasterbars.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Raster Bars (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -69,13 +69,21 @@ module top_rasterbars #(parameter CORDW=10) (  // coordinate width
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = bar_colr;
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
         sdl_sx <= sx;
         sdl_sy <= sy;
         sdl_de <= de;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};  // double signal width from 4 to 8 bits
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/racing-the-beam/simple_480p.sv
+++ b/graphics/racing-the-beam/simple_480p.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Simple 640x480p60 Display
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none

--- a/graphics/racing-the-beam/simple_720p.sv
+++ b/graphics/racing-the-beam/simple_720p.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Simple 1280x720p60 Display
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none

--- a/graphics/racing-the-beam/xc7-hd/nexys_video.xdc
+++ b/graphics/racing-the-beam/xc7-hd/nexys_video.xdc
@@ -1,5 +1,5 @@
 ## Project F: Racing the Beam - Nexys Video Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/racing-the-beam/
 
 ## FPGA Configuration I/O Options

--- a/graphics/racing-the-beam/xc7-hd/top_bounce.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_bounce.sv
@@ -123,10 +123,10 @@ module top_bounce (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_bounce.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_bounce.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Bounce (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -101,12 +101,20 @@ module top_bounce (
         square = (sx >= qx) && (sx < qx + Q_SIZE) && (sy >= qy) && (sy < qy + Q_SIZE);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
         paint_g = (square) ? 4'hF : 4'h3;
         paint_b = (square) ? 4'hF : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -116,9 +124,9 @@ module top_bounce (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_colour_cycle.sv
@@ -88,10 +88,10 @@ module top_colour_cycle (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_colour_cycle.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Cycle (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -66,12 +66,20 @@ module top_colour_cycle (
         end
     end
 
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = sx[8:5];  // 32 horizontal pixels of each red level
         paint_g = sy[8:5];  // 32 vertical pixels of each green level
         paint_b = colr_level;  // blue level changes over time
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -81,9 +89,9 @@ module top_colour_cycle (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_hello.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_hello.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hello (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -46,7 +46,7 @@ module top_hello (
         .de
     );
 
-    // bitmap: big-endian vector, so we can write pixels left to right
+    // bitmap: MSB first, so we can write pixels left to right
     /* verilator lint_off LITENDIAN */
     logic [0:19] bmap [11];  // 20 pixels by 11 lines
     /* verilator lint_on LITENDIAN */
@@ -65,7 +65,7 @@ module top_hello (
         bmap[10] = 20'b1110_1100_1010_1110_1110;
     end
 
-    // paint at 32x scale in active screen area
+    // paint at 64x scale in active screen area
     logic picture;
     logic [4:0] x;  // 20 columns need five bits
     logic [3:0] y;  // 11 rows need four bits
@@ -75,12 +75,20 @@ module top_hello (
         picture = de ? bmap[y][x] : 0;  // look up pixel (unless we're in blanking)
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (picture) ? 4'hF : 4'h1;
         paint_g = (picture) ? 4'hC : 4'h3;
         paint_b = (picture) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -90,9 +98,9 @@ module top_hello (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_hello.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_hello.sv
@@ -97,10 +97,10 @@ module top_hello (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_hitomezashi.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_hitomezashi.sv
@@ -91,10 +91,10 @@ module top_hitomezashi (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_hitomezashi.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_hitomezashi.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hitomezashi (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -46,7 +46,7 @@ module top_hitomezashi (
         .de
     );
 
-    // stitch start values: big-endian vector, so we can write left to right
+    // stitch start values: MSB first, so we can write left to right
     /* verilator lint_off LITENDIAN */
     logic [0:39] v_start;  // 40 vertical lines
     logic [0:21] h_start;  // 22 horizontal lines
@@ -57,7 +57,7 @@ module top_hitomezashi (
         h_start = 22'b10111_01001_00001_10100_00;
     end
 
-    // paint stitch pattern with 16x16 pixel grid
+    // paint stitch pattern with 32x32 pixel grid
     logic stitch;
     logic v_line, v_on;
     logic h_line, h_on;
@@ -69,12 +69,20 @@ module top_hitomezashi (
         stitch = (v_line && v_on) || (h_line && h_on);
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (stitch) ? 4'hF : 4'h1;
         paint_g = (stitch) ? 4'hC : 4'h3;
         paint_b = (stitch) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -84,9 +92,9 @@ module top_hitomezashi (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_rasterbars.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_rasterbars.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Raster Bars (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -82,6 +82,14 @@ module top_rasterbars (
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = bar_colr;
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // DVI signals (8 bits per colour channel)
     logic [7:0] dvi_r, dvi_g, dvi_b;
     logic dvi_hsync, dvi_vsync, dvi_de;
@@ -89,9 +97,9 @@ module top_rasterbars (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
+        dvi_g     <= {2{display_g}};
+        dvi_b     <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/top_rasterbars.sv
+++ b/graphics/racing-the-beam/xc7-hd/top_rasterbars.sv
@@ -96,10 +96,10 @@ module top_rasterbars (
     always_ff @(posedge clk_pix) begin
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
-        dvi_de    <= de;
-        dvi_r     <= {2{display_r}};  // double signal width from 4 to 8 bits
-        dvi_g     <= {2{display_g}};
-        dvi_b     <= {2{display_b}};
+        dvi_de <= de;
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/racing-the-beam/xc7-hd/vivado/create_project.tcl
+++ b/graphics/racing-the-beam/xc7-hd/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Racing the Beam - Create Vivado Project (Nexys Video)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/racing-the-beam/
 
 puts "INFO: Project F - Racing the Beam Project Creation Script"

--- a/graphics/racing-the-beam/xc7/arty.xdc
+++ b/graphics/racing-the-beam/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: Racing the Beam - Arty A7-35T Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/racing-the-beam/
 
 ## FPGA Configuration I/O Options

--- a/graphics/racing-the-beam/xc7/top_bounce.sv
+++ b/graphics/racing-the-beam/xc7/top_bounce.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Bounce (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -99,7 +99,7 @@ module top_bounce (
         square = (sx >= qx) && (sx < qx + Q_SIZE) && (sy >= qy) && (sy < qy + Q_SIZE);
     end
 
-    // paint colours: white inside square, blue outside
+    // paint colour: white inside square, blue outside
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (square) ? 4'hF : 4'h1;
@@ -107,18 +107,20 @@ module top_bounce (
         paint_b = (square) ? 4'hF : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/racing-the-beam/xc7/top_colour_cycle.sv
+++ b/graphics/racing-the-beam/xc7/top_colour_cycle.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Colour Cycle (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -64,7 +64,7 @@ module top_colour_cycle (
         end
     end
 
-    // determine colour from screen position
+    // paint colour: based on screen position
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = sx[7:4];  // 16 horizontal pixels of each red level
@@ -72,18 +72,20 @@ module top_colour_cycle (
         paint_b = colr_level;  // blue level changes over time
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/racing-the-beam/xc7/top_hello.sv
+++ b/graphics/racing-the-beam/xc7/top_hello.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Hello (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -44,7 +44,7 @@ module top_hello (
         .de
     );
 
-    // bitmap: big-endian vector, so we can write pixels left to right
+    // bitmap: MSB first, so we can write pixels left to right
     /* verilator lint_off LITENDIAN */
     logic [0:19] bmap [15];  // 20 pixels by 15 lines
     /* verilator lint_on LITENDIAN */
@@ -77,7 +77,7 @@ module top_hello (
         picture = de ? bmap[y][x] : 0;  // look up pixel (unless we're in blanking)
     end
 
-    // paint colours: yellow lines, blue background
+    // paint colour: yellow lines, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (picture) ? 4'hF : 4'h1;
@@ -85,18 +85,20 @@ module top_hello (
         paint_b = (picture) ? 4'h0 : 4'h7;
     end
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/racing-the-beam/xc7/top_rasterbars.sv
+++ b/graphics/racing-the-beam/xc7/top_rasterbars.sv
@@ -1,5 +1,5 @@
 // Project F: Racing the Beam - Raster Bars (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/racing-the-beam/
 
 `default_nettype none
@@ -80,18 +80,20 @@ module top_rasterbars (
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = bar_colr;
 
+    // display colour: black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/racing-the-beam/xc7/vivado/create_project.tcl
+++ b/graphics/racing-the-beam/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Racing the Beam - Create Vivado Project
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/racing-the-beam/
 
 puts "INFO: Project F - Racing the Beam Project Creation Script"


### PR DESCRIPTION
Discussion #139 (Improving the Colour Test code for analog VGA) got me thinking about how I handle colour signals in the blanking interval. After some thought, I concluded I should explicitly set the colour to black as a stage in all designs, rather than relying on ad-hoc painting logic to remember to set it.

I have made this change for _FPGA Graphics_ and _Racing the Beam_ designs and their blog posts and will roll it out to the rest of my designs over the next few weeks.

This change also reports which tools I have tested with and removes mention of bit endianess from source comments.