### PR TITLE
Add links to Mandelbrot log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Maths & Algorithms is our latest tutorial series:
 * **Ad Astra**: [Designs](demos/ad-astra) - [Blog](https://projectf.io/posts/fpga-ad-astra/) - greetings with starfields and hardware sprites
 * **Castle Drawing**: [Designs](demos/castle-drawing) - [Blog](https://projectf.io/posts/castle-drawing/) - draw a castle and rainbow in 16 colours
 * **Life on Screen**: [Designs](demos/life-on-screen) - [Blog](https://projectf.io/posts/life-on-screen/) - Conway's Game of Life in logic
-* **Mandelbrot Set**: [Designs](demos/mandelbrot) - Blog (coming soon) - Mandelbrot set with fixed-point maths
+* **Mandelbrot Set**: [Designs](demos/mandelbrot) - [Blog](https://projectf.io/posts/mandelbrot-verilog/) - Mandelbrot set with fixed-point maths
 * **Rasterbars**: [Designs](demos/rasterbars) - [Blog](https://projectf.io/posts/rasterbars/) - classic animated colour bars
 * **Sine Scroller**: [Designs](demos/sinescroll) - [Blog](https://projectf.io/posts/sinescroll/) - greet your viewers in style
 

--- a/demos/mandelbrot/README.md
+++ b/demos/mandelbrot/README.md
@@ -2,7 +2,7 @@
 
 This SystemVerilog demo uses fixed-point multiplication and a small framebuffer to render the Mandelbrot set.
 
-This design has an associated Project F blog post: _Mandelbrot Set in Verilog_ (coming soon).
+This design has an associated Project F blog post: [Mandelbrot Set in Verilog](https://projectf.io/posts/mandelbrot-verilog/).
 
 I've included project files for:
 

--- a/demos/mandelbrot/xc7-dvi/top_mandel.sv
+++ b/demos/mandelbrot/xc7-dvi/top_mandel.sv
@@ -1,4 +1,4 @@
-// Project F: Mandelbrot Set (Nexys Video DVI)
+// Project F: Mandelbrot Set (XC7 DVI)
 // (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/mandelbrot-set-verilog/
 

--- a/demos/mandelbrot/xc7-vga/top_mandel.sv
+++ b/demos/mandelbrot/xc7-vga/top_mandel.sv
@@ -1,4 +1,4 @@
-// Project F: Mandelbrot Set (Arty Pmod VGA)
+// Project F: Mandelbrot Set (XC7 VGA)
 // (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/mandelbrot-set-verilog/
 


### PR DESCRIPTION
Also fixes Mandelbrot top headers to mention architecture, rather than specific board.