### PR TITLE
Better Blanking: Hardware Sprites

### DIFF
--- a/graphics/hardware-sprites/ice40/Makefile
+++ b/graphics/hardware-sprites/ice40/Makefile
@@ -38,7 +38,7 @@ hedgehog: hedgehog.rpt hedgehog.bin
 %.bin: %.asc
 	icepack $< $(subst top_,,$@)
 
-all: tinyf_inline tinyf_rom tinyf_scale hourglass hedgehog
+all: tinyf_inline tinyf_rom tinyf_scale tinyf_move hourglass hedgehog
 
 clean:
 	rm -f *.json *.asc *.rpt *.bin *yosys.log

--- a/graphics/hardware-sprites/ice40/Makefile
+++ b/graphics/hardware-sprites/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: Hardware Sprites - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/hardware-sprites/
 
 # configuration

--- a/graphics/hardware-sprites/ice40/icebreaker.pcf
+++ b/graphics/hardware-sprites/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: Hardware Sprites - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/hardware-sprites/
 
 ## Board Clock: 12 MHz

--- a/graphics/hardware-sprites/ice40/top_hedgehog.sv
+++ b/graphics/hardware-sprites/ice40/top_hedgehog.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hedgehog (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -139,9 +139,17 @@ module top_hedgehog (
         end
     end
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : bg_colr;
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // DVI Pmod output
     SB_IO #(
@@ -149,7 +157,7 @@ module top_hedgehog (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/ice40/top_hourglass.sv
+++ b/graphics/hardware-sprites/ice40/top_hourglass.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hourglass (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -111,9 +111,17 @@ module top_hourglass (
     logic drawing_t1;
     always_ff @(posedge clk_pix) drawing_t1 <= drawing && (spr_pix_indx != TRANS_INDX);
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : BG_COLR;
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // DVI Pmod output
     SB_IO #(
@@ -121,7 +129,7 @@ module top_hourglass (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/ice40/top_tinyf_inline.sv
+++ b/graphics/hardware-sprites/ice40/top_tinyf_inline.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F Inline (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -74,12 +74,20 @@ module top_tinyf_inline (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -88,7 +96,7 @@ module top_tinyf_inline (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/ice40/top_tinyf_move.sv
+++ b/graphics/hardware-sprites/ice40/top_tinyf_move.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Motion (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -106,12 +106,20 @@ module top_tinyf_move (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -120,7 +128,7 @@ module top_tinyf_move (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/ice40/top_tinyf_rom.sv
+++ b/graphics/hardware-sprites/ice40/top_tinyf_rom.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F from ROM (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -76,12 +76,20 @@ module top_tinyf_rom (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -90,7 +98,7 @@ module top_tinyf_rom (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/ice40/top_tinyf_scale.sv
+++ b/graphics/hardware-sprites/ice40/top_tinyf_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Scaling (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -85,12 +85,20 @@ module top_tinyf_scale (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI Pmod output
@@ -99,7 +107,7 @@ module top_tinyf_scale (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/hardware-sprites/lint.sh
+++ b/graphics/hardware-sprites/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Project F: Lint Script
-# (C)2022 Will Green, open source software released under the MIT License
+# (C)2023 Will Green, open source software released under the MIT License
 # Learn more at https://projectf.io
 
 DIR=`dirname $0`

--- a/graphics/hardware-sprites/sim/top_hedgehog.sv
+++ b/graphics/hardware-sprites/sim/top_hedgehog.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hedgehog (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -125,9 +125,17 @@ module top_hedgehog #(parameter CORDW=16) (  // signed coordinate width (bits)
         end
     end
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : bg_colr;
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -135,8 +143,8 @@ module top_hedgehog #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sim/top_hourglass.sv
+++ b/graphics/hardware-sprites/sim/top_hourglass.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hourglass (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -95,9 +95,17 @@ module top_hourglass #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic drawing_t1;
     always_ff @(posedge clk_pix) drawing_t1 <= drawing && (spr_pix_indx != TRANS_INDX);
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : BG_COLR;
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -105,8 +113,8 @@ module top_hourglass #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sim/top_tinyf_inline.sv
+++ b/graphics/hardware-sprites/sim/top_tinyf_inline.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F Inline (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -58,12 +58,20 @@ module top_tinyf_inline #(parameter CORDW=16) (  // signed coordinate width (bit
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // SDL output (8 bits per colour channel)
@@ -72,8 +80,8 @@ module top_tinyf_inline #(parameter CORDW=16) (  // signed coordinate width (bit
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sim/top_tinyf_move.sv
+++ b/graphics/hardware-sprites/sim/top_tinyf_move.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Motion (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -92,12 +92,20 @@ module top_tinyf_move #(parameter CORDW=16) (  // signed coordinate width (bits)
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // SDL output (8 bits per colour channel)
@@ -106,8 +114,8 @@ module top_tinyf_move #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sim/top_tinyf_rom.sv
+++ b/graphics/hardware-sprites/sim/top_tinyf_rom.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F from ROM (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -60,12 +60,20 @@ module top_tinyf_rom #(parameter CORDW=16) (  // signed coordinate width (bits)
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // SDL output (8 bits per colour channel)
@@ -74,8 +82,8 @@ module top_tinyf_rom #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sim/top_tinyf_scale.sv
+++ b/graphics/hardware-sprites/sim/top_tinyf_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Scaling (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -69,12 +69,20 @@ module top_tinyf_scale #(parameter CORDW=16) (  // signed coordinate width (bits
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // SDL output (8 bits per colour channel)
@@ -83,8 +91,8 @@ module top_tinyf_scale #(parameter CORDW=16) (  // signed coordinate width (bits
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width from 4 to 8 bits
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/hardware-sprites/sprite.sv
+++ b/graphics/hardware-sprites/sprite.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite with Scaling
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none

--- a/graphics/hardware-sprites/sprite_rom.sv
+++ b/graphics/hardware-sprites/sprite_rom.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite from ROM
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none

--- a/graphics/hardware-sprites/xc7-hd/nexys_video.xdc
+++ b/graphics/hardware-sprites/xc7-hd/nexys_video.xdc
@@ -1,5 +1,5 @@
 ## Project F: Hardware Sprites - Nexys Video Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/hardware-sprites/
 
 ## FPGA Configuration I/O Options

--- a/graphics/hardware-sprites/xc7-hd/top_hedgehog.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_hedgehog.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hedgehog (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -142,9 +142,17 @@ module top_hedgehog (
         end
     end
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : bg_colr;
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // DVI signals (8 bits per colour channel)
     logic [7:0] dvi_r, dvi_g, dvi_b;
@@ -153,9 +161,9 @@ module top_hedgehog (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/top_hourglass.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_hourglass.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hourglass (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -114,9 +114,17 @@ module top_hourglass (
     logic drawing_t1;
     always_ff @(posedge clk_pix) drawing_t1 <= drawing && (spr_pix_indx != TRANS_INDX);
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : BG_COLR;
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // DVI signals (8 bits per colour channel)
     logic [7:0] dvi_r, dvi_g, dvi_b;
@@ -125,9 +133,9 @@ module top_hourglass (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/top_tinyf_inline.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_tinyf_inline.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F Inline (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -77,12 +77,20 @@ module top_tinyf_inline (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -92,9 +100,9 @@ module top_tinyf_inline (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/top_tinyf_move.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_tinyf_move.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Motion (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -109,12 +109,20 @@ module top_tinyf_move (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -124,9 +132,9 @@ module top_tinyf_move (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/top_tinyf_rom.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_tinyf_rom.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F from ROM (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -79,12 +79,20 @@ module top_tinyf_rom (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -94,9 +102,9 @@ module top_tinyf_rom (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/top_tinyf_scale.sv
+++ b/graphics/hardware-sprites/xc7-hd/top_tinyf_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Scaling (Nexys Video)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -88,12 +88,20 @@ module top_tinyf_scale (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
         paint_g = (drawing && pix) ? 4'hC : 4'h3;
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
+    end
+
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
     end
 
     // DVI signals (8 bits per colour channel)
@@ -103,9 +111,9 @@ module top_tinyf_scale (
         dvi_hsync <= hsync;
         dvi_vsync <= vsync;
         dvi_de    <= de;
-        dvi_r     <= {2{paint_r}};
-        dvi_g     <= {2{paint_g}};
-        dvi_b     <= {2{paint_b}};
+        dvi_r <= {2{display_r}};
+        dvi_g <= {2{display_g}};
+        dvi_b <= {2{display_b}};
     end
 
     // TMDS encoding and serialization

--- a/graphics/hardware-sprites/xc7-hd/vivado/create_project.tcl
+++ b/graphics/hardware-sprites/xc7-hd/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Hardware Sprites - Create Vivado Project (Nexys Video)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/hardware-sprites/
 
 puts "INFO: Project F - Hardware Sprites Project Creation Script"

--- a/graphics/hardware-sprites/xc7/arty.xdc
+++ b/graphics/hardware-sprites/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: Hardware Sprites - Arty A7-35T Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/hardware-sprites/
 
 ## FPGA Configuration I/O Options

--- a/graphics/hardware-sprites/xc7/sprite_inline_tb.sv
+++ b/graphics/hardware-sprites/xc7/sprite_inline_tb.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite Inline Bitmap Test Bench
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none

--- a/graphics/hardware-sprites/xc7/sprite_rom_tb.sv
+++ b/graphics/hardware-sprites/xc7/sprite_rom_tb.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite from ROM Test Bench
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none

--- a/graphics/hardware-sprites/xc7/sprite_tb.sv
+++ b/graphics/hardware-sprites/xc7/sprite_tb.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Sprite with Scaling Test Bench
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none

--- a/graphics/hardware-sprites/xc7/top_hedgehog.sv
+++ b/graphics/hardware-sprites/xc7/top_hedgehog.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hedgehog (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -140,22 +140,24 @@ module top_hedgehog (
         end
     end
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : bg_colr;
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/top_hourglass.sv
+++ b/graphics/hardware-sprites/xc7/top_hourglass.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Hourglass (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -112,22 +112,24 @@ module top_hourglass (
     logic drawing_t1;
     always_ff @(posedge clk_pix) drawing_t1 <= drawing && (spr_pix_indx != TRANS_INDX);
 
-    // paint colours
+    // paint colour: sprite or background
     logic [CHANW-1:0] paint_r, paint_g, paint_b;
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : BG_COLR;
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/top_tinyf_inline.sv
+++ b/graphics/hardware-sprites/xc7/top_tinyf_inline.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F Inline (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -75,7 +75,7 @@ module top_tinyf_inline (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
@@ -83,18 +83,20 @@ module top_tinyf_inline (
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
     end
 
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/top_tinyf_move.sv
+++ b/graphics/hardware-sprites/xc7/top_tinyf_move.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Motion (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -107,7 +107,7 @@ module top_tinyf_move (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
@@ -115,18 +115,20 @@ module top_tinyf_move (
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
     end
 
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/top_tinyf_rom.sv
+++ b/graphics/hardware-sprites/xc7/top_tinyf_rom.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F from ROM (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -77,7 +77,7 @@ module top_tinyf_rom (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
@@ -85,18 +85,20 @@ module top_tinyf_rom (
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
     end
 
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/top_tinyf_scale.sv
+++ b/graphics/hardware-sprites/xc7/top_tinyf_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Hardware Sprites - Tiny F with Scaling (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/hardware-sprites/
 
 `default_nettype none
@@ -86,7 +86,7 @@ module top_tinyf_scale (
         .drawing
     );
 
-    // paint colours: yellow sprite, blue background
+    // paint colour: yellow sprite, blue background
     logic [3:0] paint_r, paint_g, paint_b;
     always_comb begin
         paint_r = (drawing && pix) ? 4'hF : 4'h1;
@@ -94,18 +94,20 @@ module top_tinyf_scale (
         paint_b = (drawing && pix) ? 4'h0 : 4'h7;
     end
 
+    // display colour: paint colour but black in blanking interval
+    logic [3:0] display_r, display_g, display_b;
+    always_comb begin
+        display_r = (de) ? paint_r : 4'h0;
+        display_g = (de) ? paint_g : 4'h0;
+        display_b = (de) ? paint_b : 4'h0;
+    end
+
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/hardware-sprites/xc7/vivado/create_project.tcl
+++ b/graphics/hardware-sprites/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Hardware Sprites - Create Vivado Project
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/hardware-sprites/
 
 puts "INFO: Project F - Hardware Sprites Project Creation Script"

--- a/lib/display/xc7/vivado/display_720p_tb_behav.wcfg
+++ b/lib/display/xc7/vivado/display_720p_tb_behav.wcfg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wave_config>
+   <wave_state>
+   </wave_state>
+   <db_ref_list>
+      <db_ref path="display_720p_tb_behav.wdb" id="1">
+         <top_modules>
+            <top_module name="display_720p_tb" />
+            <top_module name="glbl" />
+         </top_modules>
+      </db_ref>
+   </db_ref_list>
+   <zoom_setting>
+      <ZoomStartTime time="0.000000000 ms"></ZoomStartTime>
+      <ZoomEndTime time="18.000100001 ms"></ZoomEndTime>
+      <Cursor1Time time="18.000100000 ms"></Cursor1Time>
+   </zoom_setting>
+   <column_width_setting>
+      <NameColumnWidth column_width="108"></NameColumnWidth>
+      <ValueColumnWidth column_width="66"></ValueColumnWidth>
+   </column_width_setting>
+   <WVObjectSize size="12" />
+   <wvobject type="logic" fp_name="/display_720p_tb/rst">
+      <obj_property name="ElementShortName">rst</obj_property>
+      <obj_property name="ObjectShortName">rst</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/clk_100m">
+      <obj_property name="ElementShortName">clk_100m</obj_property>
+      <obj_property name="ObjectShortName">clk_100m</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/clk_pix">
+      <obj_property name="ElementShortName">clk_pix</obj_property>
+      <obj_property name="ObjectShortName">clk_pix</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/clk_pix_locked">
+      <obj_property name="ElementShortName">clk_pix_locked</obj_property>
+      <obj_property name="ObjectShortName">clk_pix_locked</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/rst_pix">
+      <obj_property name="ElementShortName">rst_pix</obj_property>
+      <obj_property name="ObjectShortName">rst_pix</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/display_720p_tb/sx">
+      <obj_property name="ElementShortName">sx[15:0]</obj_property>
+      <obj_property name="ObjectShortName">sx[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/display_720p_tb/sy">
+      <obj_property name="ElementShortName">sy[15:0]</obj_property>
+      <obj_property name="ObjectShortName">sy[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/hsync">
+      <obj_property name="ElementShortName">hsync</obj_property>
+      <obj_property name="ObjectShortName">hsync</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/vsync">
+      <obj_property name="ElementShortName">vsync</obj_property>
+      <obj_property name="ObjectShortName">vsync</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/de">
+      <obj_property name="ElementShortName">de</obj_property>
+      <obj_property name="ObjectShortName">de</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/frame">
+      <obj_property name="ElementShortName">frame</obj_property>
+      <obj_property name="ObjectShortName">frame</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/display_720p_tb/line">
+      <obj_property name="ElementShortName">line</obj_property>
+      <obj_property name="ObjectShortName">line</obj_property>
+   </wvobject>
+</wave_config>


### PR DESCRIPTION
Added better blanking for _Hardware Sprites_ as discussed in #139.

Also includes two minor fixes:
* Add Vivado waveform config for `display_720p` test bench
* Add `tinyf_move` to `make all` in iCEBreaker Makefile

I have tested this in simulation and on dev boards.
