### PR TITLE
Better Blanking for Bitmap Designs

### DIFF
--- a/demos/life-on-screen/xc7/vivado/create_project.tcl
+++ b/demos/life-on-screen/xc7/vivado/create_project.tcl
@@ -59,7 +59,7 @@ set design_sources [list \
   [file normalize "${lib_dir}/clock/xd.sv"] \
   [file normalize "${lib_dir}/display/display_480p.sv"] \
   [file normalize "${lib_dir}/memory/rom_async.sv"] \
-  [file normalize "${lib_dir}/memory/xc7/bram_sdp.sv"] \
+  [file normalize "${lib_dir}/memory/bram_sdp.sv"] \
   [file normalize "${origin_dir}/lib/display/framebuffer_bram.sv"] \
   [file normalize "${origin_dir}/lib/display/linebuffer.sv"] \
   [file normalize "${origin_dir}/life.sv"] \

--- a/demos/mandelbrot/lint.sh
+++ b/demos/mandelbrot/lint.sh
@@ -8,11 +8,11 @@ DIR=`dirname $0`
 LIB="${DIR}/../../lib"
 
 # Verilator Simulation
-if [ -d "${DIR}/sim" ]; then
-    echo "## Linting top modules in ${DIR}/sim"
-    for f in ${DIR}/sim/top_*\.*v; do
+if [ -d "${DIR}/verilator-sdl" ]; then
+    echo "## Linting top modules in ${DIR}/verilator-sdl"
+    for f in ${DIR}/verilator-sdl/top_*\.*v; do
         echo "##   Checking ${f}";
-        verilator --lint-only -Wall -I${DIR} -I${DIR}/sim \
+        verilator --lint-only -Wall -I${DIR} -I${DIR}/verilator-sdl \
             -I${LIB}/clock \
             -I${LIB}/display \
             -I${LIB}/essential \
@@ -39,11 +39,11 @@ if [ -d "${DIR}/ice40" ]; then
 fi
 
 # Xilinx 7 Series (VGA Output)
-if [ -d "${DIR}/xc7" ]; then
-    echo "## Linting top modules in ${DIR}/xc7"
-    for f in ${DIR}/xc7/top_*\.*v; do
+if [ -d "${DIR}/xc7-vga" ]; then
+    echo "## Linting top modules in ${DIR}/xc7-vga"
+    for f in ${DIR}/xc7-vga/top_*\.*v; do
         echo "##   Checking ${f}";
-        verilator --lint-only -Wall -I${DIR} -I${DIR}/xc7 \
+        verilator --lint-only -Wall -I${DIR} -I${DIR}/xc7-vga \
             -I${LIB}/clock     -I${LIB}/clock/xc7 \
             -I${LIB}/display   -I${LIB}/display/xc7 \
             -I${LIB}/essential -I${LIB}/essential/xc7 \

--- a/demos/mandelbrot/verilator-sdl/top_mandel.sv
+++ b/demos/mandelbrot/verilator-sdl/top_mandel.sv
@@ -332,17 +332,17 @@ module top_mandel #(parameter CORDW=16) (  // signed coordinate width (bits)
             mandel_b <= lb_colr_out;
         end else begin
             if (lb_colr_out == 0) begin  // black in the set
-                mandel_r <= 8'h00;
-                mandel_g <= 8'h00;
-                mandel_b <= 8'h00;
+                mandel_r <= 'h00;
+                mandel_g <= 'h00;
+                mandel_b <= 'h00;
             end else if (lb_colr_out <= 8'h66) begin  // blue then purple
-                mandel_r <= 8'h00 + lb_colr_out;
-                mandel_g <= 8'h00 + (lb_colr_out >> 1);  // divide by 2
-                mandel_b <= 8'h33 + lb_colr_out;
+                mandel_r <= 'h00 + lb_colr_out;
+                mandel_g <= 'h00 + (lb_colr_out >> 1);  // divide by 2
+                mandel_b <= 'h33 + lb_colr_out;
             end else begin  // turning to gold
-                mandel_r <= 8'h66 + lb_colr_out - 8'h66;
-                mandel_g <= 8'h33 + lb_colr_out - 8'h66;
-                mandel_b <= 8'h99 + 8'h66 - lb_colr_out;
+                mandel_r <= 'h66 + lb_colr_out - 'h66;
+                mandel_g <= 'h33 + lb_colr_out - 'h66;
+                mandel_b <= 'h99 + 'h66 - lb_colr_out;
             end
         end
     end
@@ -353,7 +353,7 @@ module top_mandel #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 24'h000000;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/demos/mandelbrot/verilator-sdl/top_mandel.sv
+++ b/demos/mandelbrot/verilator-sdl/top_mandel.sv
@@ -67,6 +67,7 @@ module top_mandel #(parameter CORDW=16) (  // signed coordinate width (bits)
     // colour parameters
     localparam CHANW = 8;  // colour channel width (bits)
     localparam CIDXW = 8;  // colour index width (bits)
+    localparam BG_COLR = 'h113377;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 320;  // framebuffer width in pixels
@@ -353,16 +354,12 @@ module top_mandel #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 8'h0;
-        display_g = (de) ? paint_g : 8'h0;
-        display_b = (de) ? paint_b : 8'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL signals (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin

--- a/demos/mandelbrot/xc7-dvi/top_mandel.sv
+++ b/demos/mandelbrot/xc7-dvi/top_mandel.sv
@@ -87,6 +87,7 @@ module top_mandel (
     // colour parameters
     localparam CHANW = 8;  // colour channel width (bits)
     localparam CIDXW = 8;  // colour index width (bits)
+    localparam BG_COLR = 'h113377;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 320;  // framebuffer width in pixels
@@ -373,16 +374,12 @@ module top_mandel (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 8'h0;
-        display_g = (de) ? paint_g : 8'h0;
-        display_b = (de) ? paint_b : 8'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI signals (8 bits per colour channel)
     logic [CHANW-1:0] dvi_r, dvi_g, dvi_b;

--- a/demos/mandelbrot/xc7-dvi/top_mandel.sv
+++ b/demos/mandelbrot/xc7-dvi/top_mandel.sv
@@ -352,17 +352,17 @@ module top_mandel (
             mandel_b <= lb_colr_out;
         end else begin
             if (lb_colr_out == 0) begin  // black in the set
-                mandel_r <= 8'h00;
-                mandel_g <= 8'h00;
-                mandel_b <= 8'h00;
+                mandel_r <= 'h00;
+                mandel_g <= 'h00;
+                mandel_b <= 'h00;
             end else if (lb_colr_out <= 8'h66) begin  // blue then purple
-                mandel_r <= 8'h00 + lb_colr_out;
-                mandel_g <= 8'h00 + (lb_colr_out >> 1);  // divide by 2
-                mandel_b <= 8'h33 + lb_colr_out;
+                mandel_r <= 'h00 + lb_colr_out;
+                mandel_g <= 'h00 + (lb_colr_out >> 1);  // divide by 2
+                mandel_b <= 'h33 + lb_colr_out;
             end else begin  // turning to gold
-                mandel_r <= 8'h66 + lb_colr_out - 8'h66;
-                mandel_g <= 8'h33 + lb_colr_out - 8'h66;
-                mandel_b <= 8'h99 + 8'h66 - lb_colr_out;
+                mandel_r <= 'h66 + lb_colr_out - 'h66;
+                mandel_g <= 'h33 + lb_colr_out - 'h66;
+                mandel_b <= 'h99 + 'h66 - lb_colr_out;
             end
         end
     end
@@ -373,7 +373,7 @@ module top_mandel (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 24'h000000;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/demos/mandelbrot/xc7-vga/top_mandel.sv
+++ b/demos/mandelbrot/xc7-vga/top_mandel.sv
@@ -86,6 +86,7 @@ module top_mandel (
     // colour parameters
     localparam CHANW = 8;  // colour channel width (bits)
     localparam CIDXW = 8;  // colour index width (bits)
+    localparam BG_COLR = 'h113377;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 320;  // framebuffer width in pixels
@@ -372,18 +373,14 @@ module top_mandel (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval
     /* verilator lint_off UNUSED */
     logic [CHANW-1:0] display_r, display_g, display_b;
     /* verilator lint_on UNUSED */
-    always_comb begin
-        display_r = (de) ? paint_r : 8'h0;
-        display_g = (de) ? paint_g : 8'h0;
-        display_b = (de) ? paint_b : 8'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA signals (4 bits per colour channel)
     always_ff @(posedge clk_pix) begin

--- a/demos/mandelbrot/xc7-vga/top_mandel.sv
+++ b/demos/mandelbrot/xc7-vga/top_mandel.sv
@@ -351,17 +351,17 @@ module top_mandel (
             mandel_b <= lb_colr_out;
         end else begin
             if (lb_colr_out == 0) begin  // black in the set
-                mandel_r <= 8'h00;
-                mandel_g <= 8'h00;
-                mandel_b <= 8'h00;
+                mandel_r <= 'h00;
+                mandel_g <= 'h00;
+                mandel_b <= 'h00;
             end else if (lb_colr_out <= 8'h66) begin  // blue then purple
-                mandel_r <= 8'h00 + lb_colr_out;
-                mandel_g <= 8'h00 + (lb_colr_out >> 1);  // divide by 2
-                mandel_b <= 8'h33 + lb_colr_out;
+                mandel_r <= 'h00 + lb_colr_out;
+                mandel_g <= 'h00 + (lb_colr_out >> 1);  // divide by 2
+                mandel_b <= 'h33 + lb_colr_out;
             end else begin  // turning to gold
-                mandel_r <= 8'h66 + lb_colr_out - 8'h66;
-                mandel_g <= 8'h33 + lb_colr_out - 8'h66;
-                mandel_b <= 8'h99 + 8'h66 - lb_colr_out;
+                mandel_r <= 'h66 + lb_colr_out - 'h66;
+                mandel_g <= 'h33 + lb_colr_out - 'h66;
+                mandel_b <= 'h99 + 'h66 - lb_colr_out;
             end
         end
     end
@@ -372,7 +372,7 @@ module top_mandel (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 24'h000000;
+        {paint_r, paint_g, paint_b} = paint_area ? {mandel_r, mandel_g, mandel_b} : 0;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/2d-shapes/160x90/render_circles.sv
+++ b/graphics/2d-shapes/160x90/render_circles.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Circles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/160x90/render_circles_fill.sv
+++ b/graphics/2d-shapes/160x90/render_circles_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Circles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/160x90/render_cube_fill.sv
+++ b/graphics/2d-shapes/160x90/render_cube_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Cube (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/160x90/render_rects.sv
+++ b/graphics/2d-shapes/160x90/render_rects.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Rectangles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/160x90/render_rects_fill.sv
+++ b/graphics/2d-shapes/160x90/render_rects_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Rectangles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/160x90/render_triangles_fill.sv
+++ b/graphics/2d-shapes/160x90/render_triangles_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Triangles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_circles.sv
+++ b/graphics/2d-shapes/320x180/render_circles.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Circles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_circles_fill.sv
+++ b/graphics/2d-shapes/320x180/render_circles_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Circles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_cube_fill.sv
+++ b/graphics/2d-shapes/320x180/render_cube_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Cube (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_rects.sv
+++ b/graphics/2d-shapes/320x180/render_rects.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Rectangles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_rects_fill.sv
+++ b/graphics/2d-shapes/320x180/render_rects_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Rectangles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/320x180/render_triangles_fill.sv
+++ b/graphics/2d-shapes/320x180/render_triangles_fill.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Render Filled Triangles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none

--- a/graphics/2d-shapes/ice40/Makefile
+++ b/graphics/2d-shapes/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: 2D Shapes - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-shapes/
 
 # render module version

--- a/graphics/2d-shapes/ice40/icebreaker.pcf
+++ b/graphics/2d-shapes/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: 2D Shapes - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-shapes/
 
 ## Board Clock: 12 MHz

--- a/graphics/2d-shapes/ice40/top_demo.sv
+++ b/graphics/2d-shapes/ice40/top_demo.sv
@@ -250,7 +250,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/2d-shapes/ice40/top_demo.sv
+++ b/graphics/2d-shapes/ice40/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Demo (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none
@@ -62,6 +62,7 @@ module top_demo (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 2;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/sweetie16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -248,9 +249,13 @@ module top_demo (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -258,7 +263,7 @@ module top_demo (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/2d-shapes/sim/top_demo.sv
+++ b/graphics/2d-shapes/sim/top_demo.sv
@@ -236,7 +236,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/2d-shapes/sim/top_demo.sv
+++ b/graphics/2d-shapes/sim/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Demo (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none
@@ -48,6 +48,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/sweetie16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -234,9 +235,13 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -244,8 +249,8 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/2d-shapes/xc7/arty.xdc
+++ b/graphics/2d-shapes/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: 2D Shapes - Arty A7-35 Vivado Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/fpga-shapes/
 
 ## FPGA Configuration I/O Options

--- a/graphics/2d-shapes/xc7/top_demo.sv
+++ b/graphics/2d-shapes/xc7/top_demo.sv
@@ -251,7 +251,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/2d-shapes/xc7/top_demo.sv
+++ b/graphics/2d-shapes/xc7/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: 2D Shapes - Demo (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/fpga-shapes/
 
 `default_nettype none
@@ -63,6 +63,7 @@ module top_demo (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = "sweetie16_4b.mem";  // palette file
 
     // framebuffer (FB)
@@ -249,22 +250,20 @@ module top_demo (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/2d-shapes/xc7/vivado/create_project.tcl
+++ b/graphics/2d-shapes/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: 2D Shapes - Create Vivado Project (XC7 VGA)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/fpga-shapes/
 
 puts "INFO: Project F - 2D Shapes Project Creation Script"

--- a/graphics/animated-shapes/160x90/render_cube_shatter.sv
+++ b/graphics/animated-shapes/160x90/render_cube_shatter.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Cube Pieces (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none

--- a/graphics/animated-shapes/160x90/render_square_colr.sv
+++ b/graphics/animated-shapes/160x90/render_square_colr.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Coloured Square (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none

--- a/graphics/animated-shapes/160x90/render_teleport.sv
+++ b/graphics/animated-shapes/160x90/render_teleport.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Teleport (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 // NB. Only top-left quadrant of teleport is visible at 160x90

--- a/graphics/animated-shapes/320x180/render_cube_shatter.sv
+++ b/graphics/animated-shapes/320x180/render_cube_shatter.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Cube Shatter (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none

--- a/graphics/animated-shapes/320x180/render_square_colr.sv
+++ b/graphics/animated-shapes/320x180/render_square_colr.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Coloured Square (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none

--- a/graphics/animated-shapes/320x180/render_teleport.sv
+++ b/graphics/animated-shapes/320x180/render_teleport.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Render Teleport (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none

--- a/graphics/animated-shapes/ice40/Makefile
+++ b/graphics/animated-shapes/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: Animated Shapes - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/animated-shapes/
 
 # render module version

--- a/graphics/animated-shapes/ice40/icebreaker.pcf
+++ b/graphics/animated-shapes/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: Animated Shapes - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/animated-shapes/
 
 ## Board Clock: 12 MHz

--- a/graphics/animated-shapes/ice40/top_demo.sv
+++ b/graphics/animated-shapes/ice40/top_demo.sv
@@ -294,7 +294,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/ice40/top_demo.sv
+++ b/graphics/animated-shapes/ice40/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Double Buffer Demo (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none
@@ -62,6 +62,7 @@ module top_demo (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 2;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/teleport4_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -292,9 +293,13 @@ module top_demo (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -302,7 +307,7 @@ module top_demo (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/animated-shapes/ice40/top_demo_sb.sv
+++ b/graphics/animated-shapes/ice40/top_demo_sb.sv
@@ -239,7 +239,7 @@ module top_demo_sb (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/ice40/top_demo_sb.sv
+++ b/graphics/animated-shapes/ice40/top_demo_sb.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Single Buffer Demo (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none
@@ -62,6 +62,7 @@ module top_demo_sb (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 2;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/teleport4_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -237,9 +238,13 @@ module top_demo_sb (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -247,7 +252,7 @@ module top_demo_sb (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/animated-shapes/sim/top_demo.sv
+++ b/graphics/animated-shapes/sim/top_demo.sv
@@ -280,7 +280,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/sim/top_demo.sv
+++ b/graphics/animated-shapes/sim/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Double Buffer Demo (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none
@@ -48,6 +48,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/teleport16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -278,9 +279,13 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -288,8 +293,8 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/animated-shapes/sim/top_demo_sb.sv
+++ b/graphics/animated-shapes/sim/top_demo_sb.sv
@@ -225,7 +225,7 @@ module top_demo_sb #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/sim/top_demo_sb.sv
+++ b/graphics/animated-shapes/sim/top_demo_sb.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Single Buffer Demo (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none
@@ -48,6 +48,7 @@ module top_demo_sb #(parameter CORDW=16) (  // signed coordinate width (bits)
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/teleport16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -223,9 +224,13 @@ module top_demo_sb #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -233,8 +238,8 @@ module top_demo_sb #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/animated-shapes/xc7/arty.xdc
+++ b/graphics/animated-shapes/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: Animated Shapes - Arty A7-35 Vivado Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/animated-shapes/
 
 ## FPGA Configuration I/O Options

--- a/graphics/animated-shapes/xc7/top_demo.sv
+++ b/graphics/animated-shapes/xc7/top_demo.sv
@@ -295,7 +295,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/xc7/top_demo_sb.sv
+++ b/graphics/animated-shapes/xc7/top_demo_sb.sv
@@ -1,5 +1,5 @@
 // Project F: Animated Shapes - Single Buffer Demo (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/animated-shapes/
 
 `default_nettype none
@@ -63,6 +63,7 @@ module top_demo_sb (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = "teleport16_4b.mem";  // palette file
 
     // framebuffer (FB)
@@ -238,22 +239,20 @@ module top_demo_sb (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/animated-shapes/xc7/top_demo_sb.sv
+++ b/graphics/animated-shapes/xc7/top_demo_sb.sv
@@ -240,7 +240,7 @@ module top_demo_sb (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/animated-shapes/xc7/vivado/create_project.tcl
+++ b/graphics/animated-shapes/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Animated Shapes - Create Vivado Project (VGA)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/animated-shapes/
 
 puts "INFO: Project F - Animated Shapes Project Creation Script"

--- a/graphics/framebuffers/ice40/Makefile
+++ b/graphics/framebuffers/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: Framebuffers - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/framebuffers/
 
 # configuration

--- a/graphics/framebuffers/ice40/icebreaker.pcf
+++ b/graphics/framebuffers/ice40/icebreaker.pcf
@@ -1,5 +1,5 @@
 ## Project F: Framebuffers - iCEBreaker Board Constraints (DVI)
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/framebuffers/
 
 ## Board Clock: 12 MHz

--- a/graphics/framebuffers/ice40/top_david_16colr.sv
+++ b/graphics/framebuffers/ice40/top_david_16colr.sv
@@ -132,7 +132,7 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_16colr.sv
+++ b/graphics/framebuffers/ice40/top_david_16colr.sv
@@ -67,6 +67,7 @@ module top_david_16colr (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -131,7 +132,7 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_16colr.sv
+++ b/graphics/framebuffers/ice40/top_david_16colr.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - 16 Colour David (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -131,8 +131,12 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 12'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -140,7 +144,7 @@ module top_david_16colr (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/framebuffers/ice40/top_david_fizzle.sv
+++ b/graphics/framebuffers/ice40/top_david_fizzle.sv
@@ -74,6 +74,7 @@ module top_david_fizzle (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -227,7 +228,7 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_fizzle.sv
+++ b/graphics/framebuffers/ice40/top_david_fizzle.sv
@@ -228,7 +228,7 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_fizzle.sv
+++ b/graphics/framebuffers/ice40/top_david_fizzle.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - David Fizzle (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -227,8 +227,12 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -236,7 +240,7 @@ module top_david_fizzle (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/framebuffers/ice40/top_david_mono.sv
+++ b/graphics/framebuffers/ice40/top_david_mono.sv
@@ -51,7 +51,9 @@ module top_david_mono (
     );
 
     // colour parameters
-    localparam CHANW = 4;  // colour channel width (bits)
+    localparam CHANW = 4;        // colour channel width (bits)
+    localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -102,7 +104,7 @@ module top_david_mono (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? {COLRW{fb_colr_read}} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_mono.sv
+++ b/graphics/framebuffers/ice40/top_david_mono.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Mono David (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -102,8 +102,12 @@ module top_david_mono (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 12'hFFF: 12'h000;
+        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -111,7 +115,7 @@ module top_david_mono (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/framebuffers/ice40/top_david_scale.sv
+++ b/graphics/framebuffers/ice40/top_david_scale.sv
@@ -195,7 +195,7 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_scale.sv
+++ b/graphics/framebuffers/ice40/top_david_scale.sv
@@ -74,6 +74,7 @@ module top_david_scale (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -194,7 +195,7 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/ice40/top_david_scale.sv
+++ b/graphics/framebuffers/ice40/top_david_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Scaled David (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -194,8 +194,12 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -203,7 +207,7 @@ module top_david_scale (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/framebuffers/sim/top_david_16colr.sv
+++ b/graphics/framebuffers/sim/top_david_16colr.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - 16 Colour David (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -117,8 +117,12 @@ module top_david_16colr #(parameter CORDW=16) (  // signed coordinate width (bit
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 12'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -126,8 +130,8 @@ module top_david_16colr #(parameter CORDW=16) (  // signed coordinate width (bit
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/framebuffers/sim/top_david_16colr.sv
+++ b/graphics/framebuffers/sim/top_david_16colr.sv
@@ -118,7 +118,7 @@ module top_david_16colr #(parameter CORDW=16) (  // signed coordinate width (bit
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_16colr.sv
+++ b/graphics/framebuffers/sim/top_david_16colr.sv
@@ -53,6 +53,7 @@ module top_david_16colr #(parameter CORDW=16) (  // signed coordinate width (bit
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -117,7 +118,7 @@ module top_david_16colr #(parameter CORDW=16) (  // signed coordinate width (bit
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_fizzle.sv
+++ b/graphics/framebuffers/sim/top_david_fizzle.sv
@@ -58,6 +58,7 @@ module top_david_fizzle #(parameter CORDW=16) (  // signed coordinate width (bit
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -211,7 +212,7 @@ module top_david_fizzle #(parameter CORDW=16) (  // signed coordinate width (bit
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_fizzle.sv
+++ b/graphics/framebuffers/sim/top_david_fizzle.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - David Fizzle (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -211,8 +211,12 @@ module top_david_fizzle #(parameter CORDW=16) (  // signed coordinate width (bit
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -220,8 +224,8 @@ module top_david_fizzle #(parameter CORDW=16) (  // signed coordinate width (bit
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/framebuffers/sim/top_david_fizzle.sv
+++ b/graphics/framebuffers/sim/top_david_fizzle.sv
@@ -212,7 +212,7 @@ module top_david_fizzle #(parameter CORDW=16) (  // signed coordinate width (bit
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_mono.sv
+++ b/graphics/framebuffers/sim/top_david_mono.sv
@@ -37,7 +37,9 @@ module top_david_mono #(parameter CORDW=16) (  // signed coordinate width (bits)
     );
 
     // colour parameters
-    localparam CHANW = 4;  // colour channel width (bits)
+    localparam CHANW = 4;        // colour channel width (bits)
+    localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -88,7 +90,7 @@ module top_david_mono #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? {COLRW{fb_colr_read}} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_mono.sv
+++ b/graphics/framebuffers/sim/top_david_mono.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Mono David (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -88,8 +88,12 @@ module top_david_mono #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 12'hFFF: 12'h000;
+        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -97,8 +101,8 @@ module top_david_mono #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/framebuffers/sim/top_david_scale.sv
+++ b/graphics/framebuffers/sim/top_david_scale.sv
@@ -60,6 +60,7 @@ module top_david_scale #(parameter CORDW=16) (  // signed coordinate width (bits
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -180,7 +181,7 @@ module top_david_scale #(parameter CORDW=16) (  // signed coordinate width (bits
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_scale.sv
+++ b/graphics/framebuffers/sim/top_david_scale.sv
@@ -181,7 +181,7 @@ module top_david_scale #(parameter CORDW=16) (  // signed coordinate width (bits
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/sim/top_david_scale.sv
+++ b/graphics/framebuffers/sim/top_david_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Scaled David (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -180,8 +180,12 @@ module top_david_scale #(parameter CORDW=16) (  // signed coordinate width (bits
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -189,8 +193,8 @@ module top_david_scale #(parameter CORDW=16) (  // signed coordinate width (bits
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/framebuffers/xc7/arty.xdc
+++ b/graphics/framebuffers/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: Framebuffers - Arty A7-35 Vivado Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/framebuffers/
 
 ## FPGA Configuration I/O Options

--- a/graphics/framebuffers/xc7/top_david_16colr.sv
+++ b/graphics/framebuffers/xc7/top_david_16colr.sv
@@ -128,7 +128,7 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_16colr.sv
+++ b/graphics/framebuffers/xc7/top_david_16colr.sv
@@ -63,6 +63,7 @@ module top_david_16colr (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -127,7 +128,7 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_16colr.sv
+++ b/graphics/framebuffers/xc7/top_david_16colr.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - 16 Colour David (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -127,21 +127,19 @@ module top_david_16colr (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 12'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr: 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/framebuffers/xc7/top_david_fizzle.sv
+++ b/graphics/framebuffers/xc7/top_david_fizzle.sv
@@ -227,7 +227,7 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_fizzle.sv
+++ b/graphics/framebuffers/xc7/top_david_fizzle.sv
@@ -73,6 +73,7 @@ module top_david_fizzle (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -226,7 +227,7 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_fizzle.sv
+++ b/graphics/framebuffers/xc7/top_david_fizzle.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - David Fizzle (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -226,21 +226,19 @@ module top_david_fizzle (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/framebuffers/xc7/top_david_mono.sv
+++ b/graphics/framebuffers/xc7/top_david_mono.sv
@@ -50,7 +50,9 @@ module top_david_mono (
     );
 
     // colour parameters
-    localparam CHANW = 4;  // colour channel width (bits)
+    localparam CHANW = 4;        // colour channel width (bits)
+    localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -101,7 +103,7 @@ module top_david_mono (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
+        {paint_r, paint_g, paint_b} = paint_area ? {COLRW{fb_colr_read}} : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_mono.sv
+++ b/graphics/framebuffers/xc7/top_david_mono.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Mono David (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -101,21 +101,19 @@ module top_david_mono (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= 0 && sy < FB_HEIGHT && sx >= 0 && sx < FB_WIDTH);
-        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 12'hFFF: 12'h000;
+        {paint_r, paint_g, paint_b} = (paint_area && fb_colr_read) ? 'hFFF: 'h000;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/framebuffers/xc7/top_david_scale.sv
+++ b/graphics/framebuffers/xc7/top_david_scale.sv
@@ -196,7 +196,7 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/top_david_scale.sv
+++ b/graphics/framebuffers/xc7/top_david_scale.sv
@@ -1,5 +1,5 @@
 // Project F: Framebuffers - Scaled David (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/framebuffers/
 
 `default_nettype none
@@ -195,21 +195,19 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 12'h000;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/framebuffers/xc7/top_david_scale.sv
+++ b/graphics/framebuffers/xc7/top_david_scale.sv
@@ -75,6 +75,7 @@ module top_david_scale (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
 
     // framebuffer (FB)
     localparam FB_WIDTH  = 160;  // framebuffer width in pixels
@@ -195,7 +196,7 @@ module top_david_scale (
     always_comb begin
         paint_area = (sy >= 0 && sy < (FB_HEIGHT * FB_SCALE)
             && sx >= 0 && sx < FB_WIDTH * FB_SCALE);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : 'h137;
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/framebuffers/xc7/vivado/create_project.tcl
+++ b/graphics/framebuffers/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Framebuffers - Create Vivado Project (XC7 VGA)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io
 
 puts "INFO: Project F - Framebuffers Project Creation Script"

--- a/graphics/framebuffers/xc7/vivado/create_project.tcl
+++ b/graphics/framebuffers/xc7/vivado/create_project.tcl
@@ -65,7 +65,7 @@ set design_sources [list \
   [file normalize "${lib_dir}/display/display_480p.sv"] \
   [file normalize "${lib_dir}/display/linebuffer_simple.sv"] \
   [file normalize "${lib_dir}/maths/lfsr.sv"] \
-  [file normalize "${lib_dir}/memory/xc7/bram_sdp.sv"] \
+  [file normalize "${lib_dir}/memory/bram_sdp.sv"] \
 ]
 add_files -norecurse -fileset $fs_design_obj $design_sources
 

--- a/graphics/hardware-sprites/ice40/top_hedgehog.sv
+++ b/graphics/hardware-sprites/ice40/top_hedgehog.sv
@@ -128,14 +128,14 @@ module top_hedgehog (
     logic [COLRW-1:0] bg_colr;
     always_ff @(posedge clk_pix) begin
         if (line) begin
-            if      (sy == 0)   bg_colr <= 12'h239;
-            else if (sy == 80)  bg_colr <= 12'h24A;
-            else if (sy == 140) bg_colr <= 12'h25B;
-            else if (sy == 190) bg_colr <= 12'h26C;
-            else if (sy == 230) bg_colr <= 12'h27D;
-            else if (sy == 265) bg_colr <= 12'h29E;
-            else if (sy == 295) bg_colr <= 12'h2BF;
-            else if (sy == 320) bg_colr <= 12'h260;
+            if      (sy == 0)   bg_colr <= 'h239;
+            else if (sy == 80)  bg_colr <= 'h24A;
+            else if (sy == 140) bg_colr <= 'h25B;
+            else if (sy == 190) bg_colr <= 'h26C;
+            else if (sy == 230) bg_colr <= 'h27D;
+            else if (sy == 265) bg_colr <= 'h29E;
+            else if (sy == 295) bg_colr <= 'h2BF;
+            else if (sy == 320) bg_colr <= 'h260;
         end
     end
 
@@ -144,12 +144,8 @@ module top_hedgehog (
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : bg_colr;
 
     // display colour: paint colour but black in blanking interval
-    logic [3:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(

--- a/graphics/hardware-sprites/ice40/top_hourglass.sv
+++ b/graphics/hardware-sprites/ice40/top_hourglass.sv
@@ -116,12 +116,8 @@ module top_hourglass (
     always_comb {paint_r, paint_g, paint_b} = (drawing_t1) ? spr_pix_colr : BG_COLR;
 
     // display colour: paint colour but black in blanking interval
-    logic [3:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(

--- a/graphics/hardware-sprites/sim/top_hedgehog.sv
+++ b/graphics/hardware-sprites/sim/top_hedgehog.sv
@@ -114,14 +114,14 @@ module top_hedgehog #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [COLRW-1:0] bg_colr;
     always_ff @(posedge clk_pix) begin
         if (line) begin
-            if      (sy == 0)   bg_colr <= 12'h239;
-            else if (sy == 80)  bg_colr <= 12'h24A;
-            else if (sy == 140) bg_colr <= 12'h25B;
-            else if (sy == 190) bg_colr <= 12'h26C;
-            else if (sy == 230) bg_colr <= 12'h27D;
-            else if (sy == 265) bg_colr <= 12'h29E;
-            else if (sy == 295) bg_colr <= 12'h2BF;
-            else if (sy == 320) bg_colr <= 12'h260;
+            if      (sy == 0)   bg_colr <= 'h239;
+            else if (sy == 80)  bg_colr <= 'h24A;
+            else if (sy == 140) bg_colr <= 'h25B;
+            else if (sy == 190) bg_colr <= 'h26C;
+            else if (sy == 230) bg_colr <= 'h27D;
+            else if (sy == 265) bg_colr <= 'h29E;
+            else if (sy == 295) bg_colr <= 'h2BF;
+            else if (sy == 320) bg_colr <= 'h260;
         end
     end
 
@@ -131,11 +131,7 @@ module top_hedgehog #(parameter CORDW=16) (  // signed coordinate width (bits)
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin

--- a/graphics/hardware-sprites/sim/top_hourglass.sv
+++ b/graphics/hardware-sprites/sim/top_hourglass.sv
@@ -101,11 +101,7 @@ module top_hourglass #(parameter CORDW=16) (  // signed coordinate width (bits)
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin

--- a/graphics/hardware-sprites/xc7/top_hedgehog.sv
+++ b/graphics/hardware-sprites/xc7/top_hedgehog.sv
@@ -129,14 +129,14 @@ module top_hedgehog (
     logic [COLRW-1:0] bg_colr;
     always_ff @(posedge clk_pix) begin
         if (line) begin
-            if      (sy == 0)   bg_colr <= 12'h239;
-            else if (sy == 80)  bg_colr <= 12'h24A;
-            else if (sy == 140) bg_colr <= 12'h25B;
-            else if (sy == 190) bg_colr <= 12'h26C;
-            else if (sy == 230) bg_colr <= 12'h27D;
-            else if (sy == 265) bg_colr <= 12'h29E;
-            else if (sy == 295) bg_colr <= 12'h2BF;
-            else if (sy == 320) bg_colr <= 12'h260;
+            if      (sy == 0)   bg_colr <= 'h239;
+            else if (sy == 80)  bg_colr <= 'h24A;
+            else if (sy == 140) bg_colr <= 'h25B;
+            else if (sy == 190) bg_colr <= 'h26C;
+            else if (sy == 230) bg_colr <= 'h27D;
+            else if (sy == 265) bg_colr <= 'h29E;
+            else if (sy == 295) bg_colr <= 'h2BF;
+            else if (sy == 320) bg_colr <= 'h260;
         end
     end
 
@@ -146,11 +146,7 @@ module top_hedgehog (
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin

--- a/graphics/hardware-sprites/xc7/top_hourglass.sv
+++ b/graphics/hardware-sprites/xc7/top_hourglass.sv
@@ -118,11 +118,7 @@ module top_hourglass (
 
     // display colour: paint colour but black in blanking interval
     logic [CHANW-1:0] display_r, display_g, display_b;
-    always_comb begin
-        display_r = (de) ? paint_r : 4'h0;
-        display_g = (de) ? paint_g : 4'h0;
-        display_b = (de) ? paint_b : 4'h0;
-    end
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin

--- a/graphics/lines-and-triangles/160x90/render_cube.sv
+++ b/graphics/lines-and-triangles/160x90/render_cube.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Cube (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/160x90/render_edge.sv
+++ b/graphics/lines-and-triangles/160x90/render_edge.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Framebuffer Edge (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/160x90/render_line.sv
+++ b/graphics/lines-and-triangles/160x90/render_line.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Line (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/160x90/render_triangles.sv
+++ b/graphics/lines-and-triangles/160x90/render_triangles.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Triangles (2-bit 160x90)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/320x180/render_cube.sv
+++ b/graphics/lines-and-triangles/320x180/render_cube.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Cube (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/320x180/render_edge.sv
+++ b/graphics/lines-and-triangles/320x180/render_edge.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Framebuffer Edge (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/320x180/render_line.sv
+++ b/graphics/lines-and-triangles/320x180/render_line.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Line (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/320x180/render_triangles.sv
+++ b/graphics/lines-and-triangles/320x180/render_triangles.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Render Triangles (4-bit 320x180)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/ice40/Makefile
+++ b/graphics/lines-and-triangles/ice40/Makefile
@@ -1,5 +1,5 @@
 ## Project F: Lines and Triangles - iCEBreaker Makefile
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/lines-and-triangles/
 
 # render module version

--- a/graphics/lines-and-triangles/ice40/top_demo.sv
+++ b/graphics/lines-and-triangles/ice40/top_demo.sv
@@ -250,7 +250,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/lines-and-triangles/ice40/top_demo.sv
+++ b/graphics/lines-and-triangles/ice40/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Demo (iCEBreaker 12-bit DVI Pmod)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/ice40/top_demo.sv
+++ b/graphics/lines-and-triangles/ice40/top_demo.sv
@@ -62,6 +62,7 @@ module top_demo (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 2;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/sweetie16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -248,9 +249,13 @@ module top_demo (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // DVI Pmod output
     SB_IO #(
@@ -258,7 +263,7 @@ module top_demo (
     ) dvi_signal_io [14:0] (
         .PACKAGE_PIN({dvi_hsync, dvi_vsync, dvi_de, dvi_r, dvi_g, dvi_b}),
         .OUTPUT_CLK(clk_pix),
-        .D_OUT_0({hsync, vsync, de, paint_r, paint_g, paint_b}),
+        .D_OUT_0({hsync, vsync, de, display_r, display_g, display_b}),
         /* verilator lint_off PINCONNECTEMPTY */
         .D_OUT_1()
         /* verilator lint_on PINCONNECTEMPTY */

--- a/graphics/lines-and-triangles/sim/top_demo.sv
+++ b/graphics/lines-and-triangles/sim/top_demo.sv
@@ -236,7 +236,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/lines-and-triangles/sim/top_demo.sv
+++ b/graphics/lines-and-triangles/sim/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Demo (Verilator SDL)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/sim/top_demo.sv
+++ b/graphics/lines-and-triangles/sim/top_demo.sv
@@ -48,6 +48,7 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = {LIB_RES,"/palettes/sweetie16_4b.mem"};  // palette file
 
     // framebuffer (FB)
@@ -234,9 +235,13 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // SDL output (8 bits per colour channel)
     always_ff @(posedge clk_pix) begin
@@ -244,8 +249,8 @@ module top_demo #(parameter CORDW=16) (  // signed coordinate width (bits)
         sdl_sy <= sy;
         sdl_de <= de;
         sdl_frame <= frame;
-        sdl_r <= {2{paint_r}};  // double signal width (assumes CHANW=4)
-        sdl_g <= {2{paint_g}};
-        sdl_b <= {2{paint_b}};
+        sdl_r <= {2{display_r}};
+        sdl_g <= {2{display_g}};
+        sdl_b <= {2{display_b}};
     end
 endmodule

--- a/graphics/lines-and-triangles/xc7/arty.xdc
+++ b/graphics/lines-and-triangles/xc7/arty.xdc
@@ -1,5 +1,5 @@
 ## Project F: Lines and Triangles - Arty A7-35 Vivado Board Constraints
-## (C)2022 Will Green, open source hardware released under the MIT License
+## (C)2023 Will Green, open source hardware released under the MIT License
 ## Learn more at https://projectf.io/posts/lines-and-triangles/
 
 ## FPGA Configuration I/O Options

--- a/graphics/lines-and-triangles/xc7/top_demo.sv
+++ b/graphics/lines-and-triangles/xc7/top_demo.sv
@@ -1,5 +1,5 @@
 // Project F: Lines and Triangles - Demo (Arty Pmod VGA)
-// (C)2022 Will Green, open source hardware released under the MIT License
+// (C)2023 Will Green, open source hardware released under the MIT License
 // Learn more at https://projectf.io/posts/lines-and-triangles/
 
 `default_nettype none

--- a/graphics/lines-and-triangles/xc7/top_demo.sv
+++ b/graphics/lines-and-triangles/xc7/top_demo.sv
@@ -251,7 +251,7 @@ module top_demo (
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
             && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
+        {paint_r, paint_g, paint_b} = paint_area ? fb_pix_colr : BG_COLR;
     end
 
     // display colour: paint colour but black in blanking interval

--- a/graphics/lines-and-triangles/xc7/top_demo.sv
+++ b/graphics/lines-and-triangles/xc7/top_demo.sv
@@ -63,6 +63,7 @@ module top_demo (
     localparam CHANW = 4;        // colour channel width (bits)
     localparam COLRW = 3*CHANW;  // colour width: three channels (bits)
     localparam CIDXW = 4;        // colour index width (bits)
+    localparam BG_COLR = 'h137;  // background colour
     localparam PAL_FILE = "sweetie16_4b.mem";  // palette file
 
     // framebuffer (FB)
@@ -249,22 +250,20 @@ module top_demo (
     logic [CHANW-1:0] paint_r, paint_g, paint_b;  // colour channels
     always_comb begin
         paint_area = (sy >= FB_OFFY && sy < (FB_HEIGHT * FB_SCALE) + FB_OFFY
-            && sx >= FB_OFFX && sx < FB_WIDTH * FB_SCALE + FB_OFFX);
-        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr: 12'h000;
+            && sx >= FB_OFFX && sx < (FB_WIDTH * FB_SCALE) + FB_OFFX);
+        {paint_r, paint_g, paint_b} = (de && paint_area) ? fb_pix_colr : BG_COLR;
     end
+
+    // display colour: paint colour but black in blanking interval
+    logic [CHANW-1:0] display_r, display_g, display_b;
+    always_comb {display_r, display_g, display_b} = (de) ? {paint_r, paint_g, paint_b} : 0;
 
     // VGA Pmod output
     always_ff @(posedge clk_pix) begin
         vga_hsync <= hsync;
         vga_vsync <= vsync;
-        if (de) begin
-            vga_r <= paint_r;
-            vga_g <= paint_g;
-            vga_b <= paint_b;
-        end else begin  // VGA colour should be black in blanking interval
-            vga_r <= 4'h0;
-            vga_g <= 4'h0;
-            vga_b <= 4'h0;
-        end
+        vga_r <= display_r;
+        vga_g <= display_g;
+        vga_b <= display_b;
     end
 endmodule

--- a/graphics/lines-and-triangles/xc7/vivado/create_project.tcl
+++ b/graphics/lines-and-triangles/xc7/vivado/create_project.tcl
@@ -1,5 +1,5 @@
 # Project F: Lines and Triangles - Create Vivado Project (XC7 VGA)
-# (C)2022 Will Green, open source hardware released under the MIT License
+# (C)2023 Will Green, open source hardware released under the MIT License
 # Learn more at https://projectf.io/posts/lines-and-triangles/
 
 puts "INFO: Project F - Lines and Triangles Project Creation Script"


### PR DESCRIPTION
Apply better blanking to remaining _FPGA Graphics_ designs as discussed in #139.

Also makes background colour a parameter with a default value of 0x137 (blue).