### PR TITLE
Improve fixed-point test model

### DIFF
--- a/lib/maths/test/div.gtkw
+++ b/lib/maths/test/div.gtkw
@@ -18,8 +18,13 @@ div.done
 div.valid
 div.dbz
 div.ovf
+@40000420
+[fpshift_count] 4
 div.a[8:0]
+[fpshift_count] 4
 div.b[8:0]
+@40000421
+[fpshift_count] 4
 div.val[8:0]
 [pattern_trace] 1
 [pattern_trace] 0

--- a/lib/maths/test/div.py
+++ b/lib/maths/test/div.py
@@ -37,13 +37,14 @@ async def test_dut_divide(dut, a, b, log=True):
     while not dut.done.value:
         await RisingEdge(dut.clk)
 
-    # model quotient
-    model_val = fp_family(a / b)
+    # model quotient: covert twice to ensure division is handled consistently
+    #                 https://github.com/rwpenney/spfpm/issues/14
+    model_val = fp_family(float(fp_family(a)) / float(fp_family(b)))
 
     # divide dut result by scaling factor
     val = fp_family(dut.val.value.signed_integer/2**FBITS)
 
-    # log numberical signals
+    # log numerical signals
     if (log):
         dut._log.info('dut a:     ' + dut.a.value.binstr)
         dut._log.info('dut b:     ' + dut.b.value.binstr)

--- a/lib/maths/test/div.py
+++ b/lib/maths/test/div.py
@@ -183,10 +183,6 @@ async def min_4(dut):  # negative
     """Test -0.0625/2"""
     await test_dut_divide(dut=dut, a=-0.0625, b=2)
 
-@cocotb.test()
-async def min_5(dut):
-    """Test 1/0.2"""
-    await test_dut_divide(dut=dut, a=1, b=0.2)
 
 # max edge tests
 @cocotb.test()
@@ -208,6 +204,35 @@ async def max_3(dut):  # negative
 async def max_4(dut):  # negative
     """Test -7.9375/0.5"""
     await test_dut_divide(dut=dut, a=-7.9375, b=0.5)
+
+
+# test non-binary values (can't be precisely represented in binary)
+@cocotb.test()
+async def nonbin_1(dut):
+    """Test 1/0.2"""
+    await test_dut_divide(dut=dut, a=1, b=0.2)
+
+@cocotb.test()
+async def nonbin_2(dut):
+    """Test 1.9/0.2"""
+    await test_dut_divide(dut=dut, a=1.9, b=0.2)
+
+@cocotb.test()
+async def nonbin_3(dut):
+    """Test 0.4/0.2"""
+    await test_dut_divide(dut=dut, a=0.4, b=0.2)
+
+# test fails - model and DUT choose different sides of true value
+@cocotb.test(expect_fail=True)
+async def nonbin_4(dut):
+    """Test 3.6/0.6"""
+    await test_dut_divide(dut=dut, a=3.6, b=0.6)
+
+# test fails - model and DUT choose different sides of true value
+@cocotb.test(expect_fail=True)
+async def nonbin_5(dut):
+    """Test 0.4/0.1"""
+    await test_dut_divide(dut=dut, a=0.4, b=0.1)
 
 
 # divide by zero and overflow tests

--- a/lib/maths/test/div.py
+++ b/lib/maths/test/div.py
@@ -182,6 +182,10 @@ async def min_4(dut):  # negative
     """Test -0.0625/2"""
     await test_dut_divide(dut=dut, a=-0.0625, b=2)
 
+@cocotb.test()
+async def min_5(dut):
+    """Test 1/0.2"""
+    await test_dut_divide(dut=dut, a=1, b=0.2)
 
 # max edge tests
 @cocotb.test()

--- a/lib/maths/test/mul.py
+++ b/lib/maths/test/mul.py
@@ -38,7 +38,7 @@ async def test_dut_multiply(dut, a, b, log=True):
         await RisingEdge(dut.clk)
 
     # model product
-    model_c = fp_family(a * b)
+    model_c = fp_family(float(fp_family(a)) * float(fp_family(b)))
 
     # divide dut result by scaling factor
     val = fp_family(dut.val.value.signed_integer/2**FBITS)
@@ -177,6 +177,37 @@ async def round_neg_6(dut):
     """Test -3.5625*2.0625"""
     await test_dut_multiply(dut=dut, a=-3.5625, b=2.0625)
 
+
+# test non-binary values (can't be precisely represented in binary)
+@cocotb.test()
+async def nonbin_1(dut):
+    """Test 1*0.2"""
+    await test_dut_multiply(dut=dut, a=1, b=0.2)
+
+@cocotb.test()
+async def nonbin_2(dut):
+    """Test 1.9*0.2"""
+    await test_dut_multiply(dut=dut, a=1.9, b=0.2)
+
+@cocotb.test()
+async def nonbin_3(dut):
+    """Test 0.4/0.2"""
+    await test_dut_multiply(dut=dut, a=0.4, b=0.2)
+
+# test fails - model and DUT choose different sides of true value
+@cocotb.test(expect_fail=True)
+async def nonbin_4(dut):
+    """Test 3.6*0.6"""
+    await test_dut_multiply(dut=dut, a=3.6, b=0.6)
+
+# test fails - model and DUT choose different sides of true value
+@cocotb.test(expect_fail=True)
+async def nonbin_5(dut):
+    """Test 0.4*0.1"""
+    await test_dut_multiply(dut=dut, a=0.4, b=0.1)
+
+
+# overflow tests
 @cocotb.test()
 async def ovf_1(dut):
     """Test 8*8 [overflow]"""
@@ -207,7 +238,6 @@ async def ovf_1(dut):
     await RisingEdge(dut.clk)
     assert dut.done.value == 0, "done is not 0!"
 
-# overflow tests
 @cocotb.test()
 async def ovf_2(dut):
     """Test 5*4 [overflow]"""


### PR DESCRIPTION
Improve fixed-point test model. Add tests cases for values that can't be precisely represented in binary.

This PR also switches to fixed-point for some GTKWave signals.

Thanks to @democrito for raising issue #164, which revealed this problem.

There is still an inconsistency between how the Python fixed-point model and Verilog handle some numbers that can't be precisely represented in binary: see issue #167.