### PR TITLE
Fix display sync timings

### DIFF
--- a/lib/display/display_1080p.sv
+++ b/lib/display/display_1080p.sv
@@ -47,8 +47,8 @@ module display_1080p #(
 
     // generate horizontal and vertical sync with correct polarity
     always_ff @(posedge clk_pix) begin
-        hsync <= H_POL ? (x > HS_STA && x <= HS_END) : ~(x > HS_STA && x <= HS_END);
-        vsync <= V_POL ? (y > VS_STA && y <= VS_END) : ~(y > VS_STA && y <= VS_END);
+        hsync <= H_POL ? (x >= HS_STA && x < HS_END) : ~(x >= HS_STA && x < HS_END);
+        vsync <= V_POL ? (y >= VS_STA && y < VS_END) : ~(y >= VS_STA && y < VS_END);
         if (rst_pix) begin
             hsync <= H_POL ? 0 : 1;
             vsync <= V_POL ? 0 : 1;

--- a/lib/display/display_24x18.sv
+++ b/lib/display/display_24x18.sv
@@ -50,8 +50,8 @@ module display_24x18 #(
 
     // generate horizontal and vertical sync with correct polarity
     always_ff @(posedge clk_pix) begin
-        hsync <= H_POL ? (x > HS_STA && x <= HS_END) : ~(x > HS_STA && x <= HS_END);
-        vsync <= V_POL ? (y > VS_STA && y <= VS_END) : ~(y > VS_STA && y <= VS_END);
+        hsync <= H_POL ? (x >= HS_STA && x < HS_END) : ~(x >= HS_STA && x < HS_END);
+        vsync <= V_POL ? (y >= VS_STA && y < VS_END) : ~(y >= VS_STA && y < VS_END);
         if (rst_pix) begin
             hsync <= H_POL ? 0 : 1;
             vsync <= V_POL ? 0 : 1;

--- a/lib/display/display_480p.sv
+++ b/lib/display/display_480p.sv
@@ -47,8 +47,8 @@ module display_480p #(
 
     // generate horizontal and vertical sync with correct polarity
     always_ff @(posedge clk_pix) begin
-        hsync <= H_POL ? (x > HS_STA && x <= HS_END) : ~(x > HS_STA && x <= HS_END);
-        vsync <= V_POL ? (y > VS_STA && y <= VS_END) : ~(y > VS_STA && y <= VS_END);
+        hsync <= H_POL ? (x >= HS_STA && x < HS_END) : ~(x >= HS_STA && x < HS_END);
+        vsync <= V_POL ? (y >= VS_STA && y < VS_END) : ~(y >= VS_STA && y < VS_END);
         if (rst_pix) begin
             hsync <= H_POL ? 0 : 1;
             vsync <= V_POL ? 0 : 1;

--- a/lib/display/display_720p.sv
+++ b/lib/display/display_720p.sv
@@ -47,8 +47,8 @@ module display_720p #(
 
     // generate horizontal and vertical sync with correct polarity
     always_ff @(posedge clk_pix) begin
-        hsync <= H_POL ? (x > HS_STA && x <= HS_END) : ~(x > HS_STA && x <= HS_END);
-        vsync <= V_POL ? (y > VS_STA && y <= VS_END) : ~(y > VS_STA && y <= VS_END);
+        hsync <= H_POL ? (x >= HS_STA && x < HS_END) : ~(x >= HS_STA && x < HS_END);
+        vsync <= V_POL ? (y >= VS_STA && y < VS_END) : ~(y >= VS_STA && y < VS_END);
         if (rst_pix) begin
             hsync <= H_POL ? 0 : 1;
             vsync <= V_POL ? 0 : 1;


### PR DESCRIPTION
The front porch was one clock cycle too long. 

I didn't see any issues on real-world displays, but this error is unnecessary and would have been spotted sooner with better tests. I have a cocotb display test bench in another FPGA project I can add to projf-explore